### PR TITLE
check_snmp: add warning and critical thresholds to perfdata

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -573,6 +573,25 @@ main (int argc, char **argv)
 
 			if (type)
 				strncat(perfstr, type, sizeof(perfstr)-strlen(perfstr)-1);
+			if (nunits > (size_t)0 && (size_t)i < nunits && unitv[i] != NULL) {
+				xasprintf (&temp_string, "%s", unitv[i]);
+				strncat(perfstr, temp_string, sizeof(perfstr)-strlen(perfstr)-1);
+				}
+
+
+			if (thlds[i]->warning || thlds[i]->critical) {
+				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
+				if (thlds[i]->warning) {
+					xasprintf (&temp_string, "%.0f", thlds[i]->warning->end);
+					strncat(perfstr, temp_string, sizeof(perfstr)-strlen(perfstr)-1);
+				}
+				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
+				if (thlds[i]->critical) {
+					xasprintf (&temp_string, "%.0f", thlds[i]->critical->end);
+					strncat(perfstr, temp_string, sizeof(perfstr)-strlen(perfstr)-1);
+				}
+				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
+			}
 			strncat(perfstr, " ", sizeof(perfstr)-strlen(perfstr)-1);
 		}
 	}


### PR DESCRIPTION
This pull request adds warning and critical thresholds to perfdata.
