### PR TITLE
Explicitly initialise timeout_sta pointer

### DIFF
--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -188,7 +188,7 @@ parse_timeout_string (char *timeout_str)
 {
 	char *seperated_str;
         char *timeout_val = "";
-	char *timeout_sta;
+	char *timeout_sta = NULL;
         if ( strstr(timeout_str, ":" ) == NULL) {
 		timeout_val = timeout_str;
         } else if ( strncmp(timeout_str, ":", 1 ) == 0) {


### PR DESCRIPTION
Hey 

I was getting segfaults when running `-t 1`  (or any number) for the `timeout_state` branch. It seems that because `timeout_sta` was not initialised, it ended up passing the check for !NULL.
