### PR TITLE
Add support for showing name (DNS) resolution in the `check_ping` plugin output (STDOUT).

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -54,6 +54,7 @@ void print_usage (void);
 void print_help (void);
 
 int display_html = FALSE;
+int show_resolution = FALSE;
 int wpl = UNKNOWN_PACKET_LOSS;
 int cpl = UNKNOWN_PACKET_LOSS;
 float wrta = UNKNOWN_TRIP_TIME;
@@ -66,6 +67,9 @@ int verbose = 0;
 
 float rta = UNKNOWN_TRIP_TIME;
 int pl = UNKNOWN_PACKET_LOSS;
+
+char ping_name[256];
+char ping_ip_addr[64];
 
 char *warn_text;
 
@@ -159,6 +163,9 @@ main (int argc, char **argv)
 		else
 			printf (_("PING %s - %sPacket loss = %d%%, RTA = %2.2f ms"),
 							state_text (this_result), warn_text, pl, rta);
+		if (show_resolution)
+			printf (" - %s (%s)", ping_name, ping_ip_addr);
+
 		if (display_html == TRUE)
 			printf ("</A>");
 
@@ -196,6 +203,7 @@ process_arguments (int argc, char **argv)
 	static struct option longopts[] = {
 		STD_LONG_OPTS,
 		{"packets", required_argument, 0, 'p'},
+		{"show-resolution", no_argument, 0, 's'},
 		{"nohtml", no_argument, 0, 'n'},
 		{"link", no_argument, 0, 'L'},
 		{"use-ipv4", no_argument, 0, '4'},
@@ -214,7 +222,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "VvhnL46t:c:w:H:p:", longopts, &option);
+		c = getopt_long (argc, argv, "VvhsnL46t:c:w:H:p:", longopts, &option);
 
 		if (c == -1 || c == EOF)
 			break;
@@ -270,6 +278,9 @@ process_arguments (int argc, char **argv)
 				max_packets = atoi (optarg);
 			else
 				usage2 (_("<max_packets> (%s) must be a non-negative number\n"), optarg);
+			break;
+		case 's':
+			show_resolution = TRUE;
 			break;
 		case 'n':	/* no HTML */
 			display_html = FALSE;
@@ -448,6 +459,10 @@ run_ping (const char *cmd, const char *addr)
 
 		result = max_state (result, error_scan (buf, addr));
 
+		if(sscanf(buf, "PING %255s (%63[^)])", &ping_name, &ping_ip_addr)){
+			continue;
+		}
+
 		/* get the percent loss statistics */
 		match = 0;
 		if((sscanf(buf,"%*d packets transmitted, %*d packets received, +%*d errors, %d%% packet loss%n",&pl,&match) && match) ||
@@ -585,6 +600,8 @@ print_help (void)
   printf (" %s\n", "-p, --packets=INTEGER");
   printf ("    %s ", _("number of ICMP ECHO packets to send"));
   printf (_("(Default: %d)\n"), DEFAULT_MAX_PACKETS);
+  	printf (" %s\n", "-s, --show-resolution");
+	printf ("    %s\n", _("show name resolution in the plugin output (DNS & IP)"));
   printf (" %s\n", "-L, --link");
   printf ("    %s\n", _("show HTML in the plugin output (obsoleted by urlize)"));
 

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -142,7 +142,7 @@ main (int argc, char **argv)
 		if (pl == UNKNOWN_PACKET_LOSS || rta < 0.0) {
 			printf ("%s\n", cmd);
 			die (STATE_UNKNOWN,
-			           _("CRITICAL - Could not interpret output from ping command\n"));
+								 _("CRITICAL - Could not interpret output from ping command\n"));
 		}
 
 		if (pl >= cpl || rta >= crta || rta < 0)
@@ -171,13 +171,13 @@ main (int argc, char **argv)
 
 		/* Print performance data */
 		printf("|%s", fperfdata ("rta", (double) rta, "ms",
-		                          wrta>0?TRUE:FALSE, wrta,
-		                          crta>0?TRUE:FALSE, crta,
-		                          TRUE, 0, FALSE, 0));
+															wrta>0?TRUE:FALSE, wrta,
+															crta>0?TRUE:FALSE, crta,
+															TRUE, 0, FALSE, 0));
 		printf(" %s\n", perfdata ("pl", (long) pl, "%",
-		                          wpl>0?TRUE:FALSE, wpl,
-		                          cpl>0?TRUE:FALSE, cpl,
-		                          TRUE, 0, FALSE, 0));
+															wpl>0?TRUE:FALSE, wpl,
+															cpl>0?TRUE:FALSE, cpl,
+															TRUE, 0, FALSE, 0));
 
 		if (verbose >= 2)
 			printf ("%f:%d%% %f:%d%%\n", wrta, wpl, crta, cpl);
@@ -562,7 +562,7 @@ error_scan (char buf[MAX_INPUT_BUFFER], const char *addr)
 		if (warn_text == NULL)
 			warn_text = strdup (_(WARN_DUPLICATES));
 		else if (! strstr (warn_text, _(WARN_DUPLICATES)) &&
-		         xasprintf (&warn_text, "%s %s", warn_text, _(WARN_DUPLICATES)) == -1)
+						 xasprintf (&warn_text, "%s %s", warn_text, _(WARN_DUPLICATES)) == -1)
 			die (STATE_UNKNOWN, _("Unable to realloc warn_text\n"));
 		return (STATE_WARNING);
 	}
@@ -582,7 +582,7 @@ print_help (void)
 
 	printf (_("Use ping to check connection statistics for a remote host."));
 
-  printf ("\n\n");
+	printf ("\n\n");
 
 	print_usage ();
 
@@ -592,31 +592,31 @@ print_help (void)
 	printf (UT_IPv46);
 
 	printf (" %s\n", "-H, --hostname=HOST");
-  printf ("    %s\n", _("host to ping"));
-  printf (" %s\n", "-w, --warning=THRESHOLD");
-  printf ("    %s\n", _("warning threshold pair"));
-  printf (" %s\n", "-c, --critical=THRESHOLD");
-  printf ("    %s\n", _("critical threshold pair"));
-  printf (" %s\n", "-p, --packets=INTEGER");
-  printf ("    %s ", _("number of ICMP ECHO packets to send"));
-  printf (_("(Default: %d)\n"), DEFAULT_MAX_PACKETS);
-  	printf (" %s\n", "-s, --show-resolution");
+	printf ("    %s\n", _("host to ping"));
+	printf (" %s\n", "-w, --warning=THRESHOLD");
+	printf ("    %s\n", _("warning threshold pair"));
+	printf (" %s\n", "-c, --critical=THRESHOLD");
+	printf ("    %s\n", _("critical threshold pair"));
+	printf (" %s\n", "-p, --packets=INTEGER");
+	printf ("    %s ", _("number of ICMP ECHO packets to send"));
+	printf (_("(Default: %d)\n"), DEFAULT_MAX_PACKETS);
+		printf (" %s\n", "-s, --show-resolution");
 	printf ("    %s\n", _("show name resolution in the plugin output (DNS & IP)"));
-  printf (" %s\n", "-L, --link");
-  printf ("    %s\n", _("show HTML in the plugin output (obsoleted by urlize)"));
+	printf (" %s\n", "-L, --link");
+	printf ("    %s\n", _("show HTML in the plugin output (obsoleted by urlize)"));
 
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 
-  printf ("\n");
+	printf ("\n");
 	printf ("%s\n", _("THRESHOLD is <rta>,<pl>% where <rta> is the round trip average travel"));
-  printf ("%s\n", _("time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"));
-  printf ("%s\n", _("percentage of packet loss to trigger an alarm state."));
+	printf ("%s\n", _("time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"));
+	printf ("%s\n", _("percentage of packet loss to trigger an alarm state."));
 
-  printf ("\n");
+	printf ("\n");
 	printf ("%s\n", _("This plugin uses the ping command to probe the specified host for packet loss"));
-  printf ("%s\n", _("(percentage) and round trip average (milliseconds). It can produce HTML output"));
-  printf ("%s\n", _("linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"));
-  printf ("%s\n", _("the contrib area of the downloads section at http://www.nagios.org/"));
+	printf ("%s\n", _("(percentage) and round trip average (milliseconds). It can produce HTML output"));
+	printf ("%s\n", _("linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"));
+	printf ("%s\n", _("the contrib area of the downloads section at http://www.nagios.org/"));
 
 	printf (UT_SUPPORT);
 }
@@ -624,7 +624,7 @@ print_help (void)
 void
 print_usage (void)
 {
-  printf ("%s\n", _("Usage:"));
+	printf ("%s\n", _("Usage:"));
 	printf ("%s -H <host_address> -w <wrta>,<wpl>%% -c <crta>,<cpl>%%\n", progname);
-  printf (" [-p packets] [-t timeout] [-4|-6]\n");
+	printf (" [-p packets] [-t timeout] [-4|-6]\n");
 }

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -142,7 +142,7 @@ main (int argc, char **argv)
 		if (pl == UNKNOWN_PACKET_LOSS || rta < 0.0) {
 			printf ("%s\n", cmd);
 			die (STATE_UNKNOWN,
-								 _("CRITICAL - Could not interpret output from ping command\n"));
+				_("CRITICAL - Could not interpret output from ping command\n"));
 		}
 
 		if (pl >= cpl || rta >= crta || rta < 0)
@@ -562,7 +562,7 @@ error_scan (char buf[MAX_INPUT_BUFFER], const char *addr)
 		if (warn_text == NULL)
 			warn_text = strdup (_(WARN_DUPLICATES));
 		else if (! strstr (warn_text, _(WARN_DUPLICATES)) &&
-						 xasprintf (&warn_text, "%s %s", warn_text, _(WARN_DUPLICATES)) == -1)
+				xasprintf (&warn_text, "%s %s", warn_text, _(WARN_DUPLICATES)) == -1)
 			die (STATE_UNKNOWN, _("Unable to realloc warn_text\n"));
 		return (STATE_WARNING);
 	}


### PR DESCRIPTION
Add support for showing name (DNS) resolution in the `check_ping` plugin output (STDOUT).

As written (alternate suggestions welcome), after being enabled with `-s` or `--show-resolution`, the output of a sample command (including the shorthand `-s` combined with the standard `-H`):

```
check_ping -sH someHost -w 3000.0,80% -c 5000.0,100% -p 5
```

... will be presented as:

```
PING OK - Packet loss = 0%, RTA = 0.63 ms - someHost.myDomain.com (10.1.2.3)
```

.. instead of the typical:

```
PING OK - Packet loss = 0%, RTA = 0.63 ms
```

In my monitoring configurations, DNS names are used whenever possible - to ensure that any failures in DNS resolution (either of the DNS service as a whole, or just for a given entry) are also reflected in the status of a host check.  The reduces the cost of recurring maintenance, as the monitoring configurations don't also need to be updated every time there is something as simple as an IP change.  Having a local DNS cache on the server (e.g. `dnsmasq`) makes any added performance expense trivial.

The default `ping` output already includes the following as the first line (as of version `iputils-sss20071127`):

```
PING someHost (10.1.2.3) 56(84) bytes of data.
```

This is potentially useful information, and this change simply makes the resolved hostname (potentially different than an input hostname) and resolved IP address available for display on the plugin output.
