### PR TITLE
fixed home variable

### DIFF
--- a/nagios-plugins.spec.in
+++ b/nagios-plugins.spec.in
@@ -155,7 +155,7 @@ fi
 %if %{islinux}
 getent passwd %{npusr} > /dev/null 2> /dev/null
 if [ $? -ne 0 ] ; then
-	useradd -r -d %{nshome} -c "%{npusr}" -g %{npgrp} %{npusr} || \
+	useradd -r -d %{nphome} -c "%{npusr}" -g %{npgrp} %{npusr} || \
 		%nnmmsg Unexpected error adding user "%{npusr}". Aborting install process.
 fi
 %endif


### PR DESCRIPTION
Hi guys, we ran into an error while running rpmbuild to create an rpm from the nagios-plugins tarball.  It looks like the reference to %{nshome} is a syntax error, as there's no other references to that name anywhere in the spec file.  We changed it to %{nphome} which is defined earlier in the spec and everything works now.

Our rpmbuild box is running centos 6.5 x64 in case it matters.  Thanks!
