### PR TITLE
Prevent large tide values from truncation (check_disk)

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -326,28 +326,28 @@ main (int argc, char **argv)
       */
 
       /* *_high_tide must be reinitialized at each run */
-      warning_high_tide = UINT_MAX;
-      critical_high_tide = UINT_MAX;
+      warning_high_tide = ULONG_MAX;
+      critical_high_tide = ULONG_MAX;
 
       if (path->freespace_units->warning != NULL) {
         warning_high_tide = path->dtotal_units - path->freespace_units->warning->end;
       }
       if (path->freespace_percent->warning != NULL) {
-        warning_high_tide = abs( min( (double) warning_high_tide, (double) (1.0 - path->freespace_percent->warning->end/100)*path->dtotal_units ));
+        warning_high_tide = labs( min( (double) warning_high_tide, (double) (1.0 - path->freespace_percent->warning->end/100)*path->dtotal_units ));
       }
       if (path->freespace_units->critical != NULL) {
         critical_high_tide = path->dtotal_units - path->freespace_units->critical->end;
       }
       if (path->freespace_percent->critical != NULL) {
-        critical_high_tide = abs( min( (double) critical_high_tide, (double) (1.0 - path->freespace_percent->critical->end/100)*path->dtotal_units ));
+        critical_high_tide = labs( min( (double) critical_high_tide, (double) (1.0 - path->freespace_percent->critical->end/100)*path->dtotal_units ));
       }
 
-      /* Nb: *_high_tide are unset when == UINT_MAX */
+      /* Nb: *_high_tide are unset when == ULONG_MAX */
       xasprintf (&perf, "%s %s", perf,
                 perfdata ((!strcmp(me->me_mountdir, "none") || display_mntp) ? me->me_devname : me->me_mountdir,
                           path->dused_units, units,
-                          (warning_high_tide != UINT_MAX ? TRUE : FALSE), warning_high_tide,
-                          (critical_high_tide != UINT_MAX ? TRUE : FALSE), critical_high_tide,
+                          (warning_high_tide != ULONG_MAX ? TRUE : FALSE), warning_high_tide,
+                          (critical_high_tide != ULONG_MAX ? TRUE : FALSE), critical_high_tide,
                           TRUE, 0,
                           TRUE, path->dtotal_units));
 


### PR DESCRIPTION
When you use "-u bytes" and a percentage as warning/critical threshold you can't target devices larger than 4 GB. The calculation is performed in a double but is truncated by abs() into an int value and then overflowed.

Like this:
```
/usr/local/nagios/libexec/check_disk -w 20% -c 10% -p / -u bytes
DISK OK - free space: / 20093124608 B (35% inode=84%);| /=37085900800B;-2147483648;-2147483648;0;60263936000
```

After changing to labs() and relevant constants to reflect the long change:
```
./plugins/check_disk -w 20% -c 10% -p / -u bytes
DISK OK - free space: / 20081324032 B (35% inode=84%);| /=37097701376B;48211148800;54237542400;0;60263936000
```