### PR TITLE
check_snmp: fix push request 1173 for SNMP responses without datatype

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -477,7 +477,7 @@ main (int argc, char **argv)
 			show = strstr (response, "Timeticks: ");
 		}
 		else
-			show = response + 3;
+			show = response;
 
 		iresult = STATE_DEPENDENT;
 


### PR DESCRIPTION
If "snmpget" returns a response without a datatype, the delimiter is skipped twice (!) without bounds check, so effective response string is read from arbitrary stack address. Really bad and hard to debug.

Example output of snmptget leading to this:

  REDHAT-CLUSTER-MIB::rhcClusterUnavailNodesNames.0 = ""

There is no datatype indicator after the equal sign in this case. 

Code skips delimiter " = " containing of 3 characters twice, reading response from last character of string + 1.

Attached commit removes the second skip.
