### PR TITLE
Unbreak netutils tcp resolving, segfault

### DIFF
--- a/plugins/netutils.c
+++ b/plugins/netutils.c
@@ -158,7 +158,7 @@ int
 np_net_connect (const char *host_name, int port, int *sd, int proto)
 {
 	struct addrinfo hints;
-	struct addrinfo *res;
+	struct addrinfo *res, *res0;
 	struct sockaddr_un su;
 	char port_str[6], host[MAX_HOST_ADDRESS_LENGTH];
 	size_t len;
@@ -185,12 +185,13 @@ np_net_connect (const char *host_name, int port, int *sd, int proto)
 		memcpy (host, host_name, len);
 		host[len] = '\0';
 		snprintf (port_str, sizeof (port_str), "%d", port);
-		result = getaddrinfo (host, port_str, &hints, &res);
+		result = getaddrinfo (host, port_str, &hints, &res0);
 
 		if (result != 0) {
 			printf ("%s\n", gai_strerror (result));
 			return STATE_UNKNOWN;
 		}
+		res = res0;
 
 		while (res) {
 			/* attempt to create a socket */
@@ -198,7 +199,7 @@ np_net_connect (const char *host_name, int port, int *sd, int proto)
 
 			if (*sd < 0) {
 				printf ("%s\n", _("Socket creation failed"));
-				freeaddrinfo (res);
+				freeaddrinfo (res0);
 				return STATE_UNKNOWN;
 			}
 
@@ -221,7 +222,7 @@ np_net_connect (const char *host_name, int port, int *sd, int proto)
 			close (*sd);
 			res = res->ai_next;
 		}
-		freeaddrinfo (res);
+		freeaddrinfo (res0);
 	}
 	/* else the hostname is interpreted as a path to a unix socket */
 	else {


### PR DESCRIPTION
The previous commit dcf0a59 caused freeaddrinfo to be called with a NULL pointer if lookup was exhausted. On FreeBSD this caused a segfault.
res0 name as in FreeBSD manpage example.
