### PR TITLE
fix Find::Bin usage

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -26,7 +26,8 @@ use English;
 use Getopt::Long;
 use File::stat;
 use vars qw($PROGNAME);
-use lib ".";
+use FindBin;
+use lib "$FindBin::Bin";
 use utils qw (%ERRORS &print_revision &support);
 
 sub print_help ();

--- a/plugins-scripts/check_mssql.pl
+++ b/plugins-scripts/check_mssql.pl
@@ -30,7 +30,8 @@
 use DBI;
 use DBD::Sybase;
 use Getopt::Long;
-use lib ".";
+use FindBin;
+use lib "$FindBin::Bin";
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 use strict;
 

--- a/plugins-scripts/check_ntp.pl
+++ b/plugins-scripts/check_ntp.pl
@@ -61,7 +61,8 @@ use POSIX;
 use strict;
 use Getopt::Long;
 use vars qw($opt_V $opt_h $opt_H $opt_t $opt_w $opt_c $opt_O $opt_j $opt_k $verbose $PROGNAME $def_jitter $ipv4 $ipv6);
-use lib utils.pm;
+use FindBin;
+use lib "$FindBin::Bin";
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 
 $PROGNAME="check_ntp";


### PR DESCRIPTION
`use lib "."` will fail if plugin is executed from other dir than `.`, i.e
filesystem root: `/`

```
$ /usr/lib/nagios/plugins/check_file_age -w 999999999 -c 999999999 -f /srv/dvideo/videos/vdp/nagios_check
Can't locate utils.pm in @INC (you may need to install the utils module) (@INC contains: . /usr/local/lib/perl5/5.18.0/x86_64-pld-linux-thread-multi /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl/5.18.0/x86_64-pld-linux-thread-multi /usr/share/perl5/vendor_perl /usr/lib64/perl5/5.18.1/x86_64-pld-linux-thread-multi /usr/share/perl5/5.18.1) at /usr/lib/nagios/plugins/check_file_age line 30.
BEGIN failed--compilation aborted at /usr/lib/nagios/plugins/check_file_age line 30.
```