### PR TITLE
fix stupid syntax error!

### DIFF
--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -35,7 +35,7 @@ use FindBin;
 use lib "$FindBin::Bin";
 use utils qw(%ERRORS &print_revision &support &usage );
 
-my ($sudo)
+my ($sudo);
 
 sub print_help ();
 sub print_usage ();


### PR DESCRIPTION
can be catched with trival compile only run:

```
$ perl -c check_mailq.pl
syntax error at check_mailq.pl line 40, near ")

sub print_help ()"
check_mailq.pl had compilation errors.
```