### PR TITLE
Revert "check_snmp: Add thresholds to performance data"

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -595,17 +595,6 @@ main (int argc, char **argv)
 			len = sizeof(perfstr)-strlen(perfstr)-1;
 			strncat(perfstr, show, len>ptr-show ? ptr-show : len);
 
-			if (warning_thresholds) {
-				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
-				strncat(perfstr, warning_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
-			}
-
-			if (critical_thresholds) {
-				if (!warning_thresholds) strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
-				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
-				strncat(perfstr, critical_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
-			}
-
 			if (type)
 				strncat(perfstr, type, sizeof(perfstr)-strlen(perfstr)-1);
 			if (nunits > (size_t)0 && (size_t)i < nunits && unitv[i] != NULL) {


### PR DESCRIPTION
This reverts commit ea8b9c750440d0ae222c7260a130b1bed6c480b6 because
multiple thresholds were shown.

You will see in the source code that just below the removed lines the "unit" will be exported and then again the thresholds.
