### PR TITLE
Use GMT timezone in SSL certs

### DIFF
--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -214,10 +214,10 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 	stamp.tm_sec = 0;
 	stamp.tm_isdst = -1;
 
-	time_left = difftime(timegm(&stamp), time(NULL));
+	tm_t = timegm(&stamp);
+	time_left = difftime(tm_t, time(NULL));
 	days_left = time_left / 86400;
-	tm_t = mktime (&stamp);
-	strftime(timestamp, 50, "%c", localtime(&tm_t));
+	strftime(timestamp, 50, "%F %R %z/%Z", localtime(&tm_t));
 
 	if (days_left > 0 && days_left <= days_till_exp_warn) {
 		printf (_("%s - Certificate '%s' expires in %d day(s) (%s).\n"), (days_left>days_till_exp_crit)?"WARNING":"CRITICAL", cn, days_left, timestamp);


### PR DESCRIPTION
SSL certs are required to use times in GMT per
https://www.ietf.org/rfc/rfc5280.txt but the mktime() here assumes the
current timezone.

Fix the time_t conversion to be done assuming GMT with timegm() and
only do it once rather than twice.

Display the expiry date and time with ISO format years and give an
offset from GMT and a timezone to be very clear about exactly what time
is being displayed. Time given is correct and now in the machine’s
timezone.
