### PR TITLE
fixed? rpmbuild errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,9 @@ dist-hook:
 install-root:
 	cd plugins-root && $(MAKE) $@
 
+install-packager:
+	cd plugins-root && $(MAKE) $@
+
 test test-debug:
 	cd lib && $(MAKE) $@
 	if test "$(PERLMODS_DIR)" != ""; then cd perlmods && $(MAKE) $@; fi

--- a/nagios-plugins.spec.in
+++ b/nagios-plugins.spec.in
@@ -163,10 +163,11 @@ fi
 %install
 rm -rf $RPM_BUILD_ROOT
 make AM_INSTALL_PROGRAM_FLAGS="" DESTDIR=${RPM_BUILD_ROOT} install
+make AM_INSTALL_PROGRAM_FLAGS="" DESTDIR=${RPM_BUILD_ROOT} install-packager
 %find_lang %{name}
 echo "%defattr(755,%{npusr},%{npgrp})" >> %{name}.lang
 comm -13 %{npdir}/ls-plugins-before %{npdir}/ls-plugins-after | egrep -v "\.o$|^\." | gawk -v libexecdir=%{_libexecdir} '{printf( "%s/%s\n", libexecdir, $0);}' >> %{name}.lang
-echo "%defattr(755,root,root)" >> %{name}.lang
+echo "%defattr(4555,root,%{npgrp})" >> %{name}.lang
 comm -13 %{npdir}/ls-plugins-root-before %{npdir}/ls-plugins-root-after | egrep -v "\.o$|^\." | gawk -v libexecdir=%{_libexecdir} '{printf( "%s/%s\n", libexecdir, $0);}' >> %{name}.lang
 echo "%defattr(755,%{npusr},%{npgrp})" >> %{name}.lang
 comm -13 %{npdir}/ls-plugins-scripts-before %{npdir}/ls-plugins-scripts-after | egrep -v "\.o$|^\." | gawk -v libexecdir=%{_libexecdir} '{printf( "%s/%s\n", libexecdir, $0);}' >> %{name}.lang
@@ -182,9 +183,8 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %files -f %{name}.lang
-%config(missingok,noreplace) %{_sysconfdir}/command.cfg
 %doc CODING COPYING FAQ INSTALL LEGAL README REQUIREMENTS SUPPORT THANKS
-%doc ChangeLog command.cfg
+%doc ChangeLog
 %if ! %{isaix}
 %{_datadir}/locale/de/LC_MESSAGES/nagios-plugins.mo
 %{_datadir}/locale/fr/LC_MESSAGES/nagios-plugins.mo

--- a/plugins-root/Makefile.am
+++ b/plugins-root/Makefile.am
@@ -52,8 +52,19 @@ INSTALL_SUID = \
 	chmod $(setuid_root_mode) $(DESTDIR)$(libexecdir)/$$p; \
 	done
 
+INSTALL_NOSUID = \
+	for f in $(noinst_PROGRAMS) ; do \
+	p=$$f; \
+	echo " $(INSTALL_PROGRAM) $$p $(DESTDIR)$(libexecdir)/$$p"; \
+	$(INSTALL_PROGRAM) $$p $(DESTDIR)$(libexecdir)/$$p; \
+	echo "NOTE: $(DESTDIR)$(libexecdir)/$$p expected to be chown/chmod by the package installer"; \
+	done
+
 install-root: $(noinst_PROGRAMS)
 	@$(INSTALL_SUID)
+
+install-packager: $(noinst_PROGRAMS)
+	@$(INSTALL_NOSUID)
 
 install-exec-local: $(noinst_PROGRAMS)
 	@TMPFILE=$(DESTDIR)$(libexecdir)/.setuid-$$$$; \


### PR DESCRIPTION
Added install option for suid scripts without chown/chmod for packaging purposes and changed the RPM spec file to what I think the correct suid/chown/chmod settings are.

Disclaimer: I am not a developer and I may not have done this the best way possible, but it seems to work for me.
