### PR TITLE
check_disk_smb: Add configfile feature

### DIFF
--- a/plugins-scripts/check_disk_smb.pl
+++ b/plugins-scripts/check_disk_smb.pl
@@ -22,7 +22,7 @@ require 5.004;
 use POSIX;
 use strict;
 use Getopt::Long;
-use vars qw($opt_P $opt_V $opt_h $opt_H $opt_s $opt_W $opt_u $opt_p $opt_w $opt_c $opt_a $verbose);
+use vars qw($opt_P $opt_V $opt_h $opt_H $opt_s $opt_W $opt_u $opt_p $opt_w $opt_c $opt_a $opt_C $verbose);
 use vars qw($PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
@@ -50,7 +50,8 @@ GetOptions
 	 "s=s" => \$opt_s, "share=s"    => \$opt_s,
 	 "W=s" => \$opt_W, "workgroup=s" => \$opt_W,
 	 "H=s" => \$opt_H, "hostname=s" => \$opt_H,
-	 "a=s" => \$opt_a, "address=s" => \$opt_a);
+ 	 "a=s" => \$opt_a, "address=s" => \$opt_a,
+	 "C=s" => \$opt_C, "configfile=s" => \$opt_C);
 
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@'); #'
@@ -87,6 +88,10 @@ my $warn = $1 if ($opt_w =~ /^([0-9]{1,2}\%?|100\%?|[0-9]+[kMG])$/);
 ($opt_c) || ($opt_c = shift @ARGV) || ($opt_c = 95);
 my $crit = $1 if ($opt_c =~ /^([0-9]{1,2}\%?|100\%?|[0-9]+[kMG])$/);
 ($crit) || usage("Invalid critical threshold: $opt_c\n");
+
+($opt_C) || ($opt_C = shift @ARGV) || ($opt_C = "");
+my $configfile = $opt_C if ($opt_C);
+usage("Unable to read config file $configfile\n") if ($configfile) && (! -r $configfile);
 
 # Execute the given command line and return anything it writes to STDOUT and/or
 # STDERR.  (This might be useful for other plugins, too, so it should possibly
@@ -188,6 +193,7 @@ my @cmd = (
 	defined($workgroup) ? ("-W", $workgroup) : (),
 	defined($address) ? ("-I", $address) : (),
 	defined($opt_P) ? ("-p", $opt_P) : (),
+	defined($configfile) ? ("-s", $configfile) : (),
 	"-c", "du"
 );
 
@@ -287,7 +293,7 @@ exit $ERRORS{$state};
 
 sub print_usage () {
 	print "Usage: $PROGNAME -H <host> -s <share> -u <user> -p <password> 
-      -w <warn> -c <crit> [-W <workgroup>] [-P <port>] [-a <IP>]\n";
+      -w <warn> -c <crit> [-W <workgroup>] [-P <port>] [-a <IP>] [-C <configfile>]\n";
 }
 
 sub print_help () {
@@ -313,11 +319,12 @@ Perl Check SMB Disk plugin for Nagios
    Password to log in to server. (Defaults to an empty password)
 -w, --warning=INTEGER or INTEGER[kMG]
    Percent of used space at which a warning will be generated (Default: 85%)
-      
 -c, --critical=INTEGER or INTEGER[kMG]
    Percent of used space at which a critical will be generated (Defaults: 95%)
 -P, --port=INTEGER
    Port to be used to connect to. Some Windows boxes use 139, others 445 (Defaults to smbclient default)
+-C, --configfile=STRING
+   Path to configfile which should be used by smbclient (Defaults to smb.conf of your smb installation)
    
    If thresholds are followed by either a k, M, or G then check to see if that
    much disk space is available (kilobytes, Megabytes, Gigabytes)


### PR DESCRIPTION
This pull request adds a new feature to check_disk_smb: configfile. As it is possible to define a separate config file in smbclient (-s option), check_disk_smb should use this possibility as well. This allows to run checks on older Samba servers where older settings are defined on server side but today's client side configurations are incompatible. Practical example: lanman auth.

Without a separate configfile and an old Samba server requiring lanman auth, the check fails:

```
# ./check_disk_smb -H sambaserver -s share -u nagios -p password
Access Denied
```

Create a special config file with different options than the default:

```
# cat /tmp/smbclientconfig.cfg 
[global]
client lanman auth = Yes
client ntlmv2 auth = No
```

And then tell the plugin to use this config file:

```
# ./check_disk_smb.new -H sambaserver -s share -u nagios -p password -C /tmp/smbclientconfig.cfg 
Disk ok - 11.95G (39%) free on \\sambaserver\share | 'share'=19374014464B;27379525222.4;30600645836.8;0;32211206144
```

In general, this allows to use the plugin with different samba client (smbclient) settings and therefore allows to check multiple (and differently configured) Samba servers without having to change the global smb.conf of the host where check_disk_smb is run from. 
