### PR TITLE
Fix for #134

### DIFF
--- a/plugins/check_game.c
+++ b/plugins/check_game.c
@@ -280,7 +280,7 @@ validate_arguments (void)
     qstat_map_field = 3;
 
   if (qstat_ping_field < 0)
-    qstat_ping_field = 5;
+    qstat_ping_field = 6;
 
   return OK;
 }


### PR DESCRIPTION
Both fields were set to 5 by default, qstat_ping_field should default to 6 for ping.