### PR TITLE
fix some gcc5 warnings

### DIFF
--- a/plugins/check_uptime.c
+++ b/plugins/check_uptime.c
@@ -37,6 +37,8 @@ char *copyright = "2014";
 char *developer = "Andy Brist";
 
 static int process_arguments (int, char **);
+int validate_arguments (void);
+int getuptime (void);
 void print_help (void);
 void print_usage (void);
 int verbose = 0;

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -91,6 +91,8 @@ void usage_va(const char *fmt, ...) __attribute__((noreturn));
 
 const char *state_text (int);
 
+int parse_timeout_string (char *timeout_str);
+
 #define max(a,b) (((a)>(b))?(a):(b))
 #define min(a,b) (((a)<(b))?(a):(b))
 


### PR DESCRIPTION
I fixed here many "warning: implicit declaration of function [-Wimplicit-function-declaration]" gcc5 warnings.