### PR TITLE
Reference redirect

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1445,13 +1445,9 @@ redir (char *pos, char *status_line)
       i = server_port_check (use_ssl);
     }
     else if (sscanf (pos, HD6, addr, url) == 2) {
-      //get type from
       if(use_ssl){
-        //i = server_port_check (use_ssl);
         strcpy (type,"https");
       }
-      //else if(sscanf(server_url,URI_HTTP,type)==1 ){
-      //}
       else{
          strcpy (type, server_type);
       }

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1365,6 +1365,9 @@ check_http (void)
 #define HD3 URI_HTTP "://" URI_HOST ":" URI_PORT
 #define HD4 URI_HTTP "://" URI_HOST
 #define HD5 URI_PATH
+/* relative reference redirect like //www.site.org/test https://tools.ietf.org/html/rfc3986 */
+#define HD6 "//" URI_HOST "/" URI_PATH
+
 
 void
 redir (char *pos, char *status_line)
@@ -1438,6 +1441,21 @@ redir (char *pos, char *status_line)
     /* URI_HTTP URI_HOST */
     else if (sscanf (pos, HD4, type, addr) == 2) {
       strcpy (url, HTTP_URL);
+      use_ssl = server_type_check (type);
+      i = server_port_check (use_ssl);
+    }
+    else if (sscanf (pos, HD6, addr, url) == 2) {
+      //get type from
+      if(use_ssl){
+        //i = server_port_check (use_ssl);
+        strcpy (type,"https");
+      }
+      //else if(sscanf(server_url,URI_HTTP,type)==1 ){
+      //}
+      else{
+         strcpy (type, server_type);
+      }
+      xasprintf (&url, "/%s", url);
       use_ssl = server_type_check (type);
       i = server_port_check (use_ssl);
     }


### PR DESCRIPTION
Referenced redirect of the format //www.server.com/folder would result in check_http trying to contact http://hostname:80//www.server.com/folder instead of http://www.server.com/folder.  Referenced redirect of this format is listed in rfc3986 ( https://tools.ietf.org/html/rfc3986 ).  It should work as expected now.
