### PR TITLE
Update check_file_age to search the $0 path for utils instead of '.'

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -25,8 +25,9 @@ use strict;
 use English;
 use Getopt::Long;
 use File::stat;
+use FindBin;
 use vars qw($PROGNAME);
-use lib ".";
+use lib "$FindBin::Bin";
 use utils qw (%ERRORS &print_revision &support);
 
 sub print_help ();


### PR DESCRIPTION
check_rpc and check_wave already use FindBin to locate dirname($0) which they use for including the utils library.  check_file_age uses "." which fails if it's being called from a different cwd than utils.pm.