### PR TITLE
Fix chunks issue in check_http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #Tooling:
 tags
 cscope.out
+nbproject/
 
 # In all paths
 NP-VERSION-FILE

--- a/build-aux/snippet/c++defs.h
+++ b/build-aux/snippet/c++defs.h
@@ -14,8 +14,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _GL_CXXDEFS_H
-#define _GL_CXXDEFS_H
+#ifndef NAGIOS_GL_CXXDEFS_H_INCLUDED
+#define NAGIOS_GL_CXXDEFS_H_INCLUDED
 
 /* The three most frequent use cases of these macros are:
 
@@ -268,4 +268,4 @@
     _GL_EXTERN_C int _gl_cxxalias_dummy
 #endif
 
-#endif /* _GL_CXXDEFS_H */
+#endif /* NAGIOS_GL_CXXDEFS_H_INCLUDED */

--- a/configure.ac
+++ b/configure.ac
@@ -620,7 +620,7 @@ AC_TRY_COMPILE([#include <sys/time.h>],
                               AC_DEFINE(NEED_GETTIMEOFDAY,1,[Define if gettimeofday is needed])))
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS(memmove select socket strdup strstr strtol strtoul floor)
+AC_CHECK_FUNCS(memmove select socket strdup strstr strtol strtoul floor sigaction)
 AC_CHECK_FUNCS(poll)
 
 AC_MSG_CHECKING(return type of socket size)

--- a/gl/dirname.h
+++ b/gl/dirname.h
@@ -16,8 +16,8 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef DIRNAME_H_
-# define DIRNAME_H_ 1
+#ifndef NAGIOS_DIRNAME_H_INCLUDED
+#define NAGIOS_DIRNAME_H_INCLUDED
 
 # include <stdbool.h>
 # include <stddef.h>
@@ -43,4 +43,4 @@ char *last_component (char const *file) _GL_ATTRIBUTE_PURE;
 
 bool strip_trailing_slashes (char *file);
 
-#endif /* not DIRNAME_H_ */
+#endif /* not NAGIOS_DIRNAME_H_INCLUDED */

--- a/gl/dosname.h
+++ b/gl/dosname.h
@@ -17,8 +17,8 @@
 
    From Paul Eggert and Jim Meyering.  */
 
-#ifndef _DOSNAME_H
-#define _DOSNAME_H
+#ifndef NAGIOS_GL_DOSNAME_H_INCLUDED
+#define NAGIOS_GL_DOSNAME_H_INCLUDED
 
 #if (defined _WIN32 || defined __WIN32__ ||     \
      defined __MSDOS__ || defined __CYGWIN__ || \

--- a/gl/error.h
+++ b/gl/error.h
@@ -16,8 +16,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _ERROR_H
-#define _ERROR_H 1
+#ifndef NAGIOS_GL_ERROR_H_INCLUDED
+#define NAGIOS_GL_ERROR_H_INCLUDED
 
 /* The __attribute__ feature is available in gcc versions 2.5 and later.
    The __-protected variants of the attributes 'format' and 'printf' are

--- a/gl/fd-hook.h
+++ b/gl/fd-hook.h
@@ -15,8 +15,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 
-#ifndef FD_HOOK_H
-#define FD_HOOK_H
+#ifndef NAGIOS_FD_HOOK_H_INCLUDED
+#define NAGIOS_FD_HOOK_H_INCLUDED
 
 #ifdef __cplusplus
 extern "C" {
@@ -116,4 +116,4 @@ extern void unregister_fd_hook (struct fd_hook *link);
 }
 #endif
 
-#endif /* FD_HOOK_H */
+#endif /* NAGIOS_FD_HOOK_H_INCLUDED */

--- a/gl/float+.h
+++ b/gl/float+.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _FLOATPLUS_H
-#define _FLOATPLUS_H
+#ifndef NAGIOS_FLOATPLUS_H_INCLUDED
+#define NAGIOS_FLOATPLUS_H_INCLUDED
 
 #include <float.h>
 #include <limits.h>
@@ -144,4 +144,4 @@ typedef int verify_sizeof_flt[SIZEOF_FLT <= sizeof (float) ? 1 : -1];
 typedef int verify_sizeof_dbl[SIZEOF_DBL <= sizeof (double) ? 1 : - 1];
 typedef int verify_sizeof_ldbl[SIZEOF_LDBL <= sizeof (long double) ? 1 : - 1];
 
-#endif /* _FLOATPLUS_H */
+#endif /* NAGIOS_FLOATPLUS_H_INCLUDED */

--- a/gl/fsusage.h
+++ b/gl/fsusage.h
@@ -18,8 +18,8 @@
 
 /* Space usage statistics for a file system.  Blocks are 512-byte. */
 
-#if !defined FSUSAGE_H_
-# define FSUSAGE_H_
+#if !defined NAGIOS_FSUSAGE_H_INCLUDED
+# define NAGIOS_FSUSAGE_H_INCLUDED
 
 # include <stdint.h>
 # include <stdbool.h>

--- a/gl/getopt_int.h
+++ b/gl/getopt_int.h
@@ -16,8 +16,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _GETOPT_INT_H
-#define _GETOPT_INT_H   1
+#ifndef NAGIOS_GL_GETOPT_INT_H_INCLUDED
+#define NAGIOS_GL_GETOPT_INT_H_INCLUDED
 
 #include <getopt.h>
 

--- a/gl/gettext.h
+++ b/gl/gettext.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _LIBGETTEXT_H
-#define _LIBGETTEXT_H 1
+#ifndef NAGIOS_GL_GETTEXT_H_INCLUDED
+#define NAGIOS_GL_GETTEXT_H_INCLUDED
 
 /* NLS can be disabled through the configure --disable-nls option.  */
 #if ENABLE_NLS
@@ -285,4 +285,4 @@ dcnpgettext_expr (const char *domain,
   return (n == 1 ? msgid : msgid_plural);
 }
 
-#endif /* _LIBGETTEXT_H */
+#endif /* NAGIOS_GL_GETTEXT_H_INCLUDED */

--- a/gl/glthread/lock.h
+++ b/gl/glthread/lock.h
@@ -75,8 +75,8 @@
 */
 
 
-#ifndef _LOCK_H
-#define _LOCK_H
+#ifndef NAGIOS_GL_LOCK_H_INCLUDED
+#define NAGIOS_GL_LOCK_H_INCLUDED
 
 #include <errno.h>
 #include <stdlib.h>
@@ -924,4 +924,4 @@ typedef int gl_once_t;
 
 /* ========================================================================= */
 
-#endif /* _LOCK_H */
+#endif /* NAGIOS_GL_LOCK_H_INCLUDED */

--- a/gl/idpriv.h
+++ b/gl/idpriv.h
@@ -14,8 +14,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _IDPRIV_H
-#define _IDPRIV_H
+#ifndef NAGIOS_GL_IDPRIV_H_INCLUDED
+#define NAGIOS_GL_IDPRIV_H_INCLUDED
 
 #ifdef __cplusplus
 extern "C" {
@@ -113,4 +113,4 @@ extern int idpriv_temp_restore (void);
 #endif
 
 
-#endif /* _IDPRIV_H */
+#endif /* NAGIOS_GL_IDPRIV_H_INCLUDED */

--- a/gl/intprops.h
+++ b/gl/intprops.h
@@ -17,8 +17,8 @@
 
 /* Written by Paul Eggert.  */
 
-#ifndef _GL_INTPROPS_H
-#define _GL_INTPROPS_H
+#ifndef NAGIOS_GL_INTPROPS_H_INCLUDED
+#define NAGIOS_GL_INTPROPS_H_INCLUDED
 
 #include <limits.h>
 
@@ -316,4 +316,4 @@
                       _GL_INT_MINIMUM (0 * (b) + (a)),          \
                       _GL_INT_MAXIMUM (0 * (b) + (a)))
 
-#endif /* _GL_INTPROPS_H */
+#endif /* NAGIOS_GL_INTPROPS_H_INCLUDED */

--- a/gl/localcharset.h
+++ b/gl/localcharset.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _LOCALCHARSET_H
-#define _LOCALCHARSET_H
+#ifndef NAGIOS_GL_LOCALCHARSET_H_INCLUDED
+#define NAGIOS_GL_LOCALCHARSET_H_INCLUDED
 
 
 #ifdef __cplusplus
@@ -37,4 +37,4 @@ extern const char * locale_charset (void);
 #endif
 
 
-#endif /* _LOCALCHARSET_H */
+#endif /* NAGIOS_GL_LOCALCHARSET_H_INCLUDED */

--- a/gl/malloca.h
+++ b/gl/malloca.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _MALLOCA_H
-#define _MALLOCA_H
+#ifndef NAGIOS_MALLOCA_H_INCLUDED
+#define NAGIOS_MALLOCA_H_INCLUDED
 
 #include <alloca.h>
 #include <stddef.h>
@@ -130,4 +130,4 @@ enum
   sa_increment = ((sizeof (int) + sa_alignment_max - 1) / sa_alignment_max) * sa_alignment_max
 };
 
-#endif /* _MALLOCA_H */
+#endif /* NAGIOS_MALLOCA_H_INCLUDED */

--- a/gl/mountlist.h
+++ b/gl/mountlist.h
@@ -16,8 +16,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef MOUNTLIST_H_
-# define MOUNTLIST_H_
+#ifndef NAGIOS_MOUNTLIST_H_INCLUDED
+# define NAGIOS_MOUNTLIST_H_INCLUDED
 
 # include <stdbool.h>
 # include <sys/types.h>

--- a/gl/msvc-inval.h
+++ b/gl/msvc-inval.h
@@ -14,8 +14,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _MSVC_INVAL_H
-#define _MSVC_INVAL_H
+#ifndef NAGIOS_MSVC_INVAL_H_INCLUDED
+#define NAGIOS_MSVC_INVAL_H_INCLUDED
 
 /* With MSVC runtime libraries with the "invalid parameter handler" concept,
    functions like fprintf(), dup2(), or close() crash when the caller passes
@@ -219,4 +219,4 @@ extern struct gl_msvc_inval_per_thread *gl_msvc_inval_current (void);
 
 #endif
 
-#endif /* _MSVC_INVAL_H */
+#endif /* NAGIOS_MSVC_INVAL_H_INCLUDED */

--- a/gl/msvc-nothrow.h
+++ b/gl/msvc-nothrow.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _MSVC_NOTHROW_H
-#define _MSVC_NOTHROW_H
+#ifndef NGAIOS_MSVC_NOTHROW_H_INCLUDED
+#define NGAIOS_MSVC_NOTHROW_H_INCLUDED
 
 /* With MSVC runtime libraries with the "invalid parameter handler" concept,
    functions like fprintf(), dup2(), or close() crash when the caller passes
@@ -40,4 +40,4 @@ extern intptr_t _gl_nothrow_get_osfhandle (int fd);
 
 #endif
 
-#endif /* _MSVC_NOTHROW_H */
+#endif /* NGAIOS_MSVC_NOTHROW_H_INCLUDED */

--- a/gl/printf-args.h
+++ b/gl/printf-args.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _PRINTF_ARGS_H
-#define _PRINTF_ARGS_H
+#ifndef NAGIOS_PRINTF_ARGS_H_INCLUDED
+#define NAGIOS_PRINTF_ARGS_H_INCLUDED
 
 /* This file can be parametrized with the following macros:
      ENABLE_UNISTDIO    Set to 1 to enable the unistdio extensions.
@@ -155,4 +155,4 @@ extern
 #endif
 int PRINTF_FETCHARGS (va_list args, arguments *a);
 
-#endif /* _PRINTF_ARGS_H */
+#endif /* NAGIOS_PRINTF_ARGS_H_INCLUDED */

--- a/gl/printf-parse.h
+++ b/gl/printf-parse.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _PRINTF_PARSE_H
-#define _PRINTF_PARSE_H
+#ifndef NAGIOS_PRINTF_PARSE_H_INCLUDED
+#define NAGIOS_PRINTF_PARSE_H_INCLUDED
 
 /* This file can be parametrized with the following macros:
      ENABLE_UNISTDIO    Set to 1 to enable the unistdio extensions.
@@ -190,4 +190,4 @@ extern
 int printf_parse (const char *format, char_directives *d, arguments *a);
 #endif
 
-#endif /* _PRINTF_PARSE_H */
+#endif /* NAGIOS_PRINTF_PARSE_H_INCLUDED */

--- a/gl/regex.h
+++ b/gl/regex.h
@@ -18,8 +18,8 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
-#ifndef _REGEX_H
-#define _REGEX_H 1
+#ifndef NAGIOS_REGEX_H_INCLUDED
+#define NAGIOS_REGEX_H_INCLUDED
 
 #include <sys/types.h>
 

--- a/gl/regex_internal.h
+++ b/gl/regex_internal.h
@@ -17,8 +17,8 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
-#ifndef _REGEX_INTERNAL_H
-#define _REGEX_INTERNAL_H 1
+#ifndef NAGIOS_REGEX_INTERNAL_H_INCLUDED
+#define NAGIOS_REGEX_INTERNAL_H_INCLUDED
 
 #include <assert.h>
 #include <ctype.h>
@@ -906,4 +906,4 @@ re_string_elem_size_at (const re_string_t *pstr, Idx idx)
 # define __attribute_warn_unused_result__ /* empty */
 #endif
 
-#endif /*  _REGEX_INTERNAL_H */
+#endif /*  NAGIOS_REGEX_INTERNAL_H_INCLUDED */

--- a/gl/sha1.h
+++ b/gl/sha1.h
@@ -16,8 +16,8 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef SHA1_H
-# define SHA1_H 1
+#ifndef NAGIOS_GL_SHA1_H_INCLUDED
+# define NAGIOS_GL_SHA1_H_INCLUDED
 
 # include <stdio.h>
 # include <stdint.h>

--- a/gl/sockets.h
+++ b/gl/sockets.h
@@ -17,8 +17,8 @@
 
 /* Written by Simon Josefsson */
 
-#ifndef SOCKETS_H
-# define SOCKETS_H 1
+#ifndef NAGIOS_SOCKETS_H_INCLUDED
+# define NAGIOS_SOCKETS_H_INCLUDED
 
 #define SOCKETS_1_0 0x100  /* don't use - does not work on Windows XP */
 #define SOCKETS_1_1 0x101
@@ -59,4 +59,4 @@ gl_fd_to_handle (int fd)
 
 #endif /* WINDOWS_SOCKETS */
 
-#endif /* SOCKETS_H */
+#endif /* NAGIOS_SOCKETS_H_INCLUDED */

--- a/gl/stdalign.in.h
+++ b/gl/stdalign.in.h
@@ -17,8 +17,8 @@
 
 /* Written by Paul Eggert and Bruno Haible.  */
 
-#ifndef _GL_STDALIGN_H
-#define _GL_STDALIGN_H
+#ifndef NAGIOS_GL_STDALIGN_H_INCLUDED
+#define NAGIOS_GL_STDALIGN_H_INCLUDED
 
 /* ISO C11 <stdalign.h> for platforms that lack it.
 
@@ -106,4 +106,4 @@
 # define __alignas_is_defined 1
 #endif
 
-#endif /* _GL_STDALIGN_H */
+#endif /* NAGIOS_GL_STDALIGN_H_INCLUDED */

--- a/gl/stdbool.in.h
+++ b/gl/stdbool.in.h
@@ -14,8 +14,8 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _GL_STDBOOL_H
-#define _GL_STDBOOL_H
+#ifndef NAGIOS_GL_STDBOOL_H_INCLUDED
+#define NAGIOS_GL_STDBOOL_H_INCLUDED
 
 /* ISO C 99 <stdbool.h> for platforms that lack it.  */
 
@@ -129,4 +129,4 @@ typedef enum { _Bool_must_promote_to_int = -1, false = 0, true = 1 } _Bool;
 
 #define __bool_true_false_are_defined 1
 
-#endif /* _GL_STDBOOL_H */
+#endif /* NAGIOS_GL_STDBOOL_H_INCLUDED */

--- a/gl/streq.h
+++ b/gl/streq.h
@@ -16,8 +16,8 @@
 
 /* Written by Bruno Haible <bruno@clisp.org>.  */
 
-#ifndef _GL_STREQ_H
-#define _GL_STREQ_H
+#ifndef NAGIOS_GL_STREQ_H_INCLUDED
+#define NAGIOS_GL_STREQ_H_INCLUDED
 
 #include <string.h>
 
@@ -173,4 +173,4 @@ streq0 (const char *s1, const char *s2, char s20, char s21, char s22, char s23, 
 
 #endif
 
-#endif /* _GL_STREQ_H */
+#endif /* NAGIOS_GL_STREQ_H_INCLUDED */

--- a/gl/strerror-override.h
+++ b/gl/strerror-override.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _GL_STRERROR_OVERRIDE_H
-# define _GL_STRERROR_OVERRIDE_H
+#ifndef NAGIOS_GL_STRERROR_OVERRIDE_H_INCLUDED
+# define NAGIOS_GL_STRERROR_OVERRIDE_H_INCLUDED
 
 # include <errno.h>
 # include <stddef.h>
@@ -53,4 +53,4 @@ extern const char *strerror_override (int errnum);
 #  define strerror_override(ignored) NULL
 # endif
 
-#endif /* _GL_STRERROR_OVERRIDE_H */
+#endif /* NAGIOS_GL_STRERROR_OVERRIDE_H_INCLUDED */

--- a/gl/vasnprintf.h
+++ b/gl/vasnprintf.h
@@ -14,8 +14,8 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _VASNPRINTF_H
-#define _VASNPRINTF_H
+#ifndef NAGIOS_GL_VASNPRINTF_H_INCLUDED
+#define NAGIOS_GL_VASNPRINTF_H_INCLUDED
 
 /* Get va_list.  */
 #include <stdarg.h>
@@ -76,4 +76,4 @@ extern char * vasnprintf (char *resultbuf, size_t *lengthp, const char *format, 
 }
 #endif
 
-#endif /* _VASNPRINTF_H */
+#endif /* NAGIOS_GL_VASNPRINTF_H_INCLUDED */

--- a/gl/verify.h
+++ b/gl/verify.h
@@ -17,8 +17,8 @@
 
 /* Written by Paul Eggert, Bruno Haible, and Jim Meyering.  */
 
-#ifndef _GL_VERIFY_H
-#define _GL_VERIFY_H
+#ifndef NAGIOS_GL_VERIFY_H_INCLUDED
+#define NAGIOS_GL_VERIFY_H_INCLUDED
 
 
 /* Define _GL_HAVE__STATIC_ASSERT to 1 if _Static_assert works as per C11.

--- a/gl/xalloc-oversized.h
+++ b/gl/xalloc-oversized.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef XALLOC_OVERSIZED_H_
-# define XALLOC_OVERSIZED_H_
+#ifndef NAGIOS_GL_XALLOC_OVERSIZED_H_INCLUDED
+# define NAGIOS_GL_XALLOC_OVERSIZED_H_INCLUDED
 
 # include <stddef.h>
 
@@ -35,4 +35,4 @@
 # define xalloc_oversized(n, s) \
     ((size_t) (sizeof (ptrdiff_t) <= sizeof (size_t) ? -1 : -2) / (s) < (n))
 
-#endif /* !XALLOC_OVERSIZED_H_ */
+#endif /* !NAGIOS_GL_XALLOC_OVERSIZED_H_INCLUDED */

--- a/gl/xalloc.h
+++ b/gl/xalloc.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef XALLOC_H_
-#define XALLOC_H_
+#ifndef NAGIOS_XALLOC_H_INCLUDED
+#define NAGIOS_XALLOC_H_INCLUDED
 
 #include <stddef.h>
 
@@ -257,4 +257,4 @@ xmemdup (T const *p, size_t s)
 #endif
 
 
-#endif /* !XALLOC_H_ */
+#endif /* !NAGIOS_XALLOC_H_INCLUDED */

--- a/gl/xsize.h
+++ b/gl/xsize.h
@@ -15,8 +15,8 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
-#ifndef _XSIZE_H
-#define _XSIZE_H
+#ifndef NAGIOS_XSIZE_H_INCLUDED
+#define NAGIOS_XSIZE_H_INCLUDED
 
 /* Get size_t.  */
 #include <stddef.h>
@@ -111,4 +111,4 @@ xmax (size_t size1, size_t size2)
 
 _GL_INLINE_HEADER_END
 
-#endif /* _XSIZE_H */
+#endif /* NAGIOS_XSIZE_H_INCLUDED */

--- a/lib/extra_opts.h
+++ b/lib/extra_opts.h
@@ -1,5 +1,5 @@
-#ifndef _EXTRA_OPTS_H_
-#define _EXTRA_OPTS_H_
+#ifndef NAGIOS_EXTRA_OPTS_H_INCLUDED
+#define NAGIOS_EXTRA_OPTS_H_INCLUDED
 
 /*
  * extra_opts.h: routines for loading nagios-plugin defaults from ini
@@ -19,5 +19,5 @@
  */
 char **np_extra_opts(int *argc, char **argv, const char *plugin_name);
 
-#endif /* _EXTRA_OPTS_H_ */
+#endif /* NAGIOS_EXTRA_OPTS_H_INCLUDED */
 

--- a/lib/parse_ini.h
+++ b/lib/parse_ini.h
@@ -1,5 +1,5 @@
-#ifndef _PARSE_INI_H_
-#define _PARSE_INI_H_
+#ifndef NAGIOS_PARSE_INI_H_INCLUDED
+#define NAGIOS_PARSE_INI_H_INCLUDED
 
 /*
  * parse_ini.h: routines for loading nagios-plugin defaults from ini
@@ -18,5 +18,5 @@ typedef struct np_arg_el {
  */
 np_arg_list* np_get_defaults(const char *locator, const char *default_section);
 
-#endif /* _PARSE_INI_H_ */
+#endif /* NAGIOS_PARSE_INI_H_INCLUDED */
 

--- a/lib/utils_base.h
+++ b/lib/utils_base.h
@@ -1,5 +1,5 @@
-#ifndef _UTILS_BASE_
-#define _UTILS_BASE_
+#ifndef NAGIOS_UTILS_BASE_H_INCLUDED
+#define NAGIOS_UTILS_BASE_H_INCLUDED
 /* Header file for nagios plugins utils_base.c */
 
 #include "sha1.h"
@@ -112,4 +112,4 @@ void np_cleanup();
 + * running a suid plugin */
 #define np_suid() (getuid() != geteuid())
 
-#endif /* _UTILS_BASE_ */
+#endif /* NAGIOS_UTILS_BASE_H_INCLUDED */

--- a/lib/utils_cmd.h
+++ b/lib/utils_cmd.h
@@ -1,5 +1,5 @@
-#ifndef _UTILS_CMD_
-#define _UTILS_CMD_
+#ifndef NAGIOS_UTILS_CMD_H_INCLUDED
+#define NAGIOS_UTILS_CMD_H_INCLUDED
 
 /* 
  * Header file for nagios plugins utils_cmd.c
@@ -32,4 +32,4 @@ void cmd_init (void);
 #define CMD_NO_ARRAYS 0x01   /* don't populate arrays at all */
 #define CMD_NO_ASSOC 0x02    /* output.line won't point to buf */
 
-#endif /* _UTILS_CMD_ */
+#endif /* NAGIOS_UTILS_CMD_H_INCLUDED */

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -35,7 +35,7 @@ use FindBin;
 use lib "$FindBin::Bin";
 use utils qw(%ERRORS &print_revision &support &usage );
 
-my ($sudo)
+my ($sudo);
 
 sub print_help ();
 sub print_usage ();

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -699,7 +699,7 @@ decode_chunked_page (const char *raw, char *dst)
 
     // move chunk from raw into dst, only if we can fit within the buffer
     if (*raw_pos && *dst_pos && (raw_pos + chunksize) < raw_end ) {
-      strncpy(dst_pos, raw_pos, chunksize);
+      memmove(dst_pos, raw_pos, chunksize);
     }
     else {
       die (STATE_UNKNOWN, _("HTTP UNKNOWN - Failed to parse chunked body, too large for destination\n"));

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -131,7 +131,17 @@ main (int argc, char **argv)
 	struct timeval tv;
 
 	/* Catch pipe errors in read/write - sometimes occurs when writing QUIT */
+#ifdef HAVE_SIGACTION
+	struct sigaction sig_action;
+
+	sig_action.sa_sigaction = NULL;
+	sig_action.sa_handler = SIG_IGN;
+	sigemptyset(&sig_action.sa_mask);
+	sig_action.sa_flags = 0;
+	sigaction(SIGPIPE, &sig_action, NULL);
+#else /* HAVE_SIGACTION */
 	(void) signal (SIGPIPE, SIG_IGN);
+#endif /* HAVE_SIGACTION */
 
 	setlocale (LC_ALL, "");
 	bindtextdomain (PACKAGE, LOCALEDIR);

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -28,8 +28,8 @@
 * 
 *****************************************************************************/
 
-#ifndef _COMMON_H_
-#define _COMMON_H_
+#ifndef NAGIOS_COMMON_H_INCLUDED
+#define NAGIOS_COMMON_H_INCLUDED
 
 #include "config.h"
 
@@ -213,4 +213,4 @@ enum {
 # define __attribute__(x) /* do nothing */
 #endif
 
-#endif /* _COMMON_H_ */
+#endif /* NAGIOS_COMMON_H_INCLUDED */

--- a/plugins/netutils.c
+++ b/plugins/netutils.c
@@ -42,10 +42,31 @@ int address_family = AF_INET;
 void
 socket_timeout_alarm_handler (int sig)
 {
+	const char msg1[] = " - Socket timeout";
+	const char msg2[] = " - Abnormal timeout";
+	switch(timeout_state) {
+		case STATE_OK:
+			write(STDOUT_FILENO, "OK", 2);
+			break;
+		case STATE_WARNING:
+			write(STDOUT_FILENO, "WARNING", 7);
+			break;
+		case STATE_CRITICAL:
+			write(STDOUT_FILENO, "CRITICAL", 8);
+			break;
+		case STATE_DEPENDENT:
+			write(STDOUT_FILENO, "DEPENDENT", 9);
+			break;
+		default:
+			write(STDOUT_FILENO, "UNKNOWN", 7);
+			break;
+	}
 	if (sig == SIGALRM)
-		printf (_("%s - Socket timeout after %d seconds\n"), state_text(timeout_state),  timeout_interval);
+		write(STDOUT_FILENO, msg1, sizeof(msg1) - 1);
+/*		printf (_("%s - Socket timeout after %d seconds\n"), state_text(timeout_state),  timeout_interval); */
 	else
-		printf (_("%s - Abnormal timeout after %d seconds\n"), state_text(timeout_state), timeout_interval);
+		write(STDOUT_FILENO, msg2, sizeof(msg2) - 1);
+/*		printf (_("%s - Abnormal timeout after %d seconds\n"), state_text(timeout_state), timeout_interval); */
 
 	exit (timeout_state);
 }

--- a/plugins/netutils.h
+++ b/plugins/netutils.h
@@ -28,8 +28,8 @@
 * 
 *****************************************************************************/
 
-#ifndef _NETUTILS_H_
-#define _NETUTILS_H_
+#ifndef NAGIOS_NETUGILS_H_INCLUDED_
+#define NAGIOS_NETUGILS_H_INCLUDED_
 
 #include "common.h"
 #include "utils.h"
@@ -100,4 +100,4 @@ int np_net_ssl_read(void *buf, int num);
 int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit);
 #endif /* HAVE_SSL */
 
-#endif /* _NETUTILS_H_ */
+#endif /* NAGIOS_NETUGILS_H_INCLUDED_ */

--- a/plugins/popen.c
+++ b/plugins/popen.c
@@ -295,16 +295,20 @@ RETSIGTYPE
 popen_timeout_alarm_handler (int signo)
 {
 	int fh;
+	const char msg1[] = "CRITICAL - Plugin timed out\n";
+	const char msg2[] = "CRITICAL - popen timeout received, but no child process\n";
 	if (signo == SIGALRM) {
 		if (child_process != NULL) {
 			fh=fileno (child_process);
 			if(fh >= 0){
 				kill (childpid[fh], SIGKILL);
 			}
-			printf (_("CRITICAL - Plugin timed out after %d seconds\n"),
-						timeout_interval);
+			/* printf (_("CRITICAL - Plugin timed out after %d seconds\n"),
+						timeout_interval); */
+			write(STDOUT_FILENO, msg1, sizeof(msg1));
 		} else {
-			printf ("%s\n", _("CRITICAL - popen timeout received, but no child process"));
+			/* printf ("%s\n", _("CRITICAL - popen timeout received, but no child process")); */
+			write(STDOUT_FILENO, msg2, sizeof(msg2));
 		}
 		exit (STATE_CRITICAL);
 	}

--- a/plugins/runcmd.c
+++ b/plugins/runcmd.c
@@ -259,9 +259,29 @@ void
 runcmd_timeout_alarm_handler (int signo)
 {
 	size_t i;
+	const char msg[] = " - Plugin timed out while executing system call\n";
 
-	if (signo == SIGALRM)
-		printf("%s - Plugin timed out while executing system call\n", state_text(timeout_state));
+	if (signo == SIGALRM) {
+		/* printf("%s - Plugin timed out while executing system call\n", state_text(timeout_state)); */
+		switch(timeout_state) {
+			case STATE_OK:
+				write(STDOUT_FILENO, "OK", 2);
+				break;
+			case STATE_WARNING:
+				write(STDOUT_FILENO, "WARNING", 7);
+				break;
+			case STATE_CRITICAL:
+				write(STDOUT_FILENO, "CRITICAL", 8);
+				break;
+			case STATE_DEPENDENT:
+				write(STDOUT_FILENO, "DEPENDENT", 9);
+				break;
+			default:
+				write(STDOUT_FILENO, "UNKNOWN", 7);
+				break;
+		}
+		write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+	}
 
 	if(np_pids) for(i = 0; i < maxfd; i++) {
 		if(np_pids[i] != 0) kill(np_pids[i], SIGKILL);

--- a/plugins/runcmd.h
+++ b/plugins/runcmd.h
@@ -21,8 +21,8 @@
 * 
 *****************************************************************************/
 
-#ifndef NAGIOSPLUG_RUNCMD_H
-#define NAGIOSPLUG_RUNCMD_H
+#ifndef NAGIOSPLUG_RUNCMD_H_INCLUDED
+#define NAGIOSPLUG_RUNCMD_H_INCLUDED
 
 #include "common.h"
 #include "utils_cmd.h" /* for the "output" type */
@@ -41,4 +41,4 @@ void np_runcmd_init(void);
 #define RUNCMD_NO_ARRAYS 0x01 /* don't populate arrays at all */
 #define RUNCMD_NO_ASSOC 0x02  /* output.line won't point to buf */
 
-#endif /* NAGIOSPLUG_RUNCMD_H */
+#endif /* NAGIOSPLUG_RUNCMD_H_INCLUDED */

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -48,7 +48,7 @@ int np_net_ssl_init_with_hostname_and_version(int sd, char *host_name, int versi
 }
 
 int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int version, char *cert, char *privkey) {
-	SSL_METHOD *method = NULL;
+	const SSL_METHOD *method = NULL;
 	long ssl_options = NULL;
 
 	switch (version) {

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -170,9 +170,28 @@ state_text (int result)
 void
 timeout_alarm_handler (int signo)
 {
+	const char msg[] = " - Plugin timed out\n";
 	if (signo == SIGALRM) {
-		printf (_("%s - Plugin timed out after %d seconds\n"),
-						state_text(timeout_state), timeout_interval);
+/*		printf (_("%s - Plugin timed out after %d seconds\n"),
+						state_text(timeout_state), timeout_interval); */
+		switch(timeout_state) {
+			case STATE_OK:
+				write(STDOUT_FILENO, "OK", 2);
+				break;
+			case STATE_WARNING:
+				write(STDOUT_FILENO, "WARNING", 7);
+				break;
+			case STATE_CRITICAL:
+				write(STDOUT_FILENO, "CRITICAL", 8);
+				break;
+			case STATE_DEPENDENT:
+				write(STDOUT_FILENO, "DEPENDENT", 9);
+				break;
+			default:
+				write(STDOUT_FILENO, "UNKNOWN", 7);
+				break;
+		}
+		write(STDOUT_FILENO, msg, sizeof(msg) - 1);
 		exit (timeout_state);
 	}
 }

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -1,5 +1,5 @@
-#ifndef NP_UTILS_H
-#define NP_UTILS_H
+#ifndef NP_UTILS_H_INCLUDED
+#define NP_UTILS_H_INCLUDED
 /* Header file for nagios plugins utils.c */
 
 /* This file should be included in all plugins */
@@ -211,4 +211,4 @@ The nagios plugins come with ABSOLUTELY NO WARRANTY. You may redistribute\n\
 copies of the plugins under the terms of the GNU General Public License.\n\
 For more information about these matters, see the file named COPYING.\n")
 
-#endif /* NP_UTILS_H */
+#endif /* NP_UTILS_H_INCLUDED */


### PR DESCRIPTION
Use memmove instead of strncpy since source and destination
point to the same memory location.

Using strncpy results in a corrupted result page in memory resulting in
false positives when using string content matching.
