### PR TITLE
Use strlen instead of sizeof in check_dns

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -496,7 +496,7 @@ process_arguments (int argc, char **argv)
     case 'q': /* querytype -- A or AAAA or ANY or SRV or TXT, etc. */
       if (strlen (optarg) < 1 || strlen (optarg) > 5)
 	die (STATE_UNKNOWN, "%s\n", _("Missing valid querytype parameter.  Try using 'A' or 'AAAA' or 'SRV'"));
-      strntoupper(optarg, sizeof(optarg));
+      strntoupper(optarg, strlen(optarg));
       strcpy(query_type, "-querytype=");
       strcat(query_type, optarg);
       query_set = TRUE;


### PR DESCRIPTION
The value given to check_dns' "-q"/"--querytype" option is converted to
uppercase. The optarg variable is of type char*, requiring the use of
strlen(). sizeof() of a char* returns the platform's pointer size
(usually 4 or 8 bytes). If the value given to "-q" is shorter, the code
ends up overwriting unrelated memory:

  $ check_dns -H nagios.com -q a --expected-address 1.2.3.4
  check_dns: unrecognized option '--EXPEcted-address'