### PR TITLE
fix: Allocator sizeof operand mismatch

### DIFF
--- a/lib/extra_opts.c
+++ b/lib/extra_opts.c
@@ -112,7 +112,7 @@ char **np_extra_opts(int *argc, char **argv, const char *plugin_name){
 	}
 
 	/* done processing arguments. now create a new argv array... */
-	argv_new=(char**)malloc((ea_num+1)*sizeof(char**));
+	argv_new=(char**)malloc((ea_num+1)*sizeof(char*));
 	if(argv_new==NULL) die(STATE_UNKNOWN, _("malloc() failed!\n"));
 
 	/* starting with program name */

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -654,7 +654,7 @@ main(int argc, char **argv)
 	}
 
 	host = list;
-	table = malloc(sizeof(struct rta_host **) * targets);
+	table = malloc(sizeof(struct rta_host *) * targets);
 	i = 0;
 	while(host) {
 		host->id = i*packets;

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -489,13 +489,13 @@ process_arguments (int argc, char **argv)
     case 'a': /* expected address */
       if (strlen (optarg) >= ADDRESS_LENGTH)
         die (STATE_UNKNOWN, "%s\n", _("Input buffer overflow"));
-      expected_address = (char **)realloc(expected_address, (expected_address_cnt+1) * sizeof(char**));
+      expected_address = (char **)realloc(expected_address, (expected_address_cnt+1) * sizeof(char*));
       expected_address[expected_address_cnt] = strdup(optarg);
       expected_address_cnt++;
       break;
     case 'q': /* querytype -- A or AAAA or ANY or SRV or TXT, etc. */
       if (strlen (optarg) < 1 || strlen (optarg) > 5)
-	die (STATE_UNKNOWN, "%s\n", _("Missing valid querytype parameter.  Try using 'A' or 'AAAA' or 'SRV'"));
+        die (STATE_UNKNOWN, "%s\n", _("Missing valid querytype parameter.  Try using 'A' or 'AAAA' or 'SRV'"));
       strntoupper(optarg, strlen(optarg));
       strcpy(query_type, "-querytype=");
       strcat(query_type, optarg);


### PR DESCRIPTION
This pull request fix the Clang warning `Allocator sizeof operand mismatch`.
Command Line: 

``` sh
make 'CFLAGS=-Wall -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security'
```

Clang Version:  `clang version 3.8.0 (tags/RELEASE_380/final)`
