### PR TITLE
fix: Dead assignment

### DIFF
--- a/plugins-root/check_dhcp.c
+++ b/plugins-root/check_dhcp.c
@@ -582,7 +582,6 @@ int get_dhcp_offer(int sock){
 		bzero(&via,sizeof(via));
 		bzero(&offer_packet,sizeof(offer_packet));
 
-		result=OK;
 		result=receive_dhcp_packet(&offer_packet,sizeof(offer_packet),sock,dhcpoffer_timeout,&source);
 
 		if(result!=OK){

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -692,9 +692,9 @@ run_checks()
 
 			/* we're still in the game, so send next packet */
 			(void)send_icmp_ping(icmp_sock, table[t]);
-			result = wait_for_reply(icmp_sock, target_interval);
+			(void)wait_for_reply(icmp_sock, target_interval);
 		}
-		result = wait_for_reply(icmp_sock, pkt_interval * targets);
+		(void)wait_for_reply(icmp_sock, pkt_interval * targets);
 	}
 
 	if(icmp_pkts_en_route && targets_alive) {
@@ -714,7 +714,7 @@ run_checks()
 		 * haven't yet */
 		if(debug) printf("Waiting for %u micro-seconds (%0.3f msecs)\n",
 						 final_wait, (float)final_wait / 1000);
-		result = wait_for_reply(icmp_sock, final_wait);
+		(void)wait_for_reply(icmp_sock, final_wait);
 	}
 }
 
@@ -1082,7 +1082,6 @@ finish(int sig)
 
 	/* iterate once more for pretty perfparse output */
 	printf("|");
-	i = 0;
 	host = list;
 	while(host) {
 		if(debug) write(STDOUT_FILENO, "\n", 1);
@@ -1273,7 +1272,7 @@ get_timevar(const char *str)
 
 	/* unit might be given as ms|m (millisec),
 	 * us|u (microsec) or just plain s, for seconds */
-	u = p = '\0';
+	p = '\0';
 	u = str[len - 1];
 	if(len >= 2 && !isdigit((int)str[len - 2])) p = str[len - 2];
 	if(p && u == 's') u = p;

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -107,7 +107,6 @@ main (int argc, char **argv)
   double elapsed_time;
   long microsec;
   struct timeval tv;
-  int multi_address;
   int parse_address = FALSE; /* This flag scans for Address: but only after Name: */
   output chld_out, chld_err;
   size_t i;
@@ -312,11 +311,6 @@ main (int argc, char **argv)
   elapsed_time = (double)microsec / 1.0e6;
 
   if (result == STATE_OK) {
-    if (strchr (address, ',') == NULL)
-      multi_address = FALSE;
-    else
-      multi_address = TRUE;
-
     result = get_status(elapsed_time, time_thresholds);
     if (result == STATE_OK) {
       printf ("%s %s: ", _("DNS"), _("OK"));

--- a/plugins/check_hpjd.c
+++ b/plugins/check_hpjd.c
@@ -146,7 +146,8 @@ main (int argc, char **argv)
 
 		line++;
 
-		temp_buffer = strtok (input_buffer, "=");
+		/* We want the string after the "=" */
+		(void)strtok (input_buffer, "=");
 		temp_buffer = strtok (NULL, "=");
 
 		if (temp_buffer == NULL && line < 13) {

--- a/plugins/check_nagios.c
+++ b/plugins/check_nagios.c
@@ -160,7 +160,7 @@ main (int argc, char **argv)
 
 	/* If we get anything on stderr, at least set warning */
 	if(chld_err.buflen)
-		result = max_state (result, STATE_WARNING);
+		(void)max_state (result, STATE_WARNING);
 
 	/* reset the alarm handler */
 	alarm (0);

--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -356,7 +356,7 @@ int best_offset_server(const ntp_server_results *slist, int nservers){
  *   we have to do it in a way that our lazy macros don't handle currently :( */
 double offset_request(const char *host, int *status){
 	int i=0, j=0, ga_result=0, num_hosts=0, *socklist=NULL, respnum=0;
-	int servers_completed=0, one_written=0, one_read=0, servers_readable=0, best_index=-1;
+	int servers_completed=0, one_read=0, servers_readable=0, best_index=-1;
 	time_t now_time=0, start_ts=0;
 	ntp_message *req=NULL;
 	double avg_offset=0.;
@@ -421,7 +421,6 @@ double offset_request(const char *host, int *status){
 		 * been touched in the past second or so and is still lacking
 		 * some responses.  for each of these servers, send a new request,
 		 * and update the "waiting" timestamp with the current time. */
-		one_written=0;
 		now_time=time(NULL);
 
 		for(i=0; i<num_hosts; i++){
@@ -431,7 +430,6 @@ double offset_request(const char *host, int *status){
 				setup_request(&req[i]);
 				write(socklist[i], &req[i], sizeof(ntp_message));
 				servers[i].waiting=now_time;
-				one_written=1;
 				break;
 			}
 		}
@@ -773,7 +771,7 @@ int main(int argc, char *argv[]){
 	bindtextdomain (PACKAGE, LOCALEDIR);
 	textdomain (PACKAGE);
 
-	result = offset_result = jitter_result = STATE_OK;
+	offset_result = jitter_result = STATE_OK;
 
 	/* Parse extra opts if any */
 	argv=np_extra_opts (&argc, argv, progname);

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -302,7 +302,7 @@ int best_offset_server(const ntp_server_results *slist, int nservers){
  *   we have to do it in a way that our lazy macros don't handle currently :( */
 double offset_request(const char *host, int *status){
 	int i=0, j=0, ga_result=0, num_hosts=0, *socklist=NULL, respnum=0;
-	int servers_completed=0, one_written=0, one_read=0, servers_readable=0, best_index=-1;
+	int servers_completed=0, one_read=0, servers_readable=0, best_index=-1;
 	time_t now_time=0, start_ts=0;
 	ntp_message *req=NULL;
 	double avg_offset=0.;
@@ -367,7 +367,6 @@ double offset_request(const char *host, int *status){
 		 * been touched in the past second or so and is still lacking
 		 * some responses. For each of these servers, send a new request,
 		 * and update the "waiting" timestamp with the current time. */
-		one_written=0;
 		now_time=time(NULL);
 
 		for(i=0; i<num_hosts; i++){
@@ -377,7 +376,6 @@ double offset_request(const char *host, int *status){
 				setup_request(&req[i]);
 				write(socklist[i], &req[i], sizeof(ntp_message));
 				servers[i].waiting=now_time;
-				one_written=1;
 				break;
 			}
 		}
@@ -549,7 +547,7 @@ int main(int argc, char *argv[]){
 	bindtextdomain (PACKAGE, LOCALEDIR);
 	textdomain (PACKAGE);
 
-	result = offset_result = STATE_OK;
+	offset_result = STATE_OK;
 
 	/* Parse extra opts if any */
 	argv=np_extra_opts (&argc, argv, progname);

--- a/plugins/check_nwstat.c
+++ b/plugins/check_nwstat.c
@@ -513,10 +513,6 @@ main(int argc, char **argv) {
 		result=send_tcp_request(sd,send_buffer,recv_buffer,sizeof(recv_buffer));
 		if (result!=STATE_OK)
 			return result;
-		if (atoi(recv_buffer)==1)
-			result=STATE_OK;
-		else
-			result=STATE_WARNING;
 
 		close(sd);
 		my_tcp_connect (server_address, server_port, &sd);
@@ -796,7 +792,6 @@ main(int argc, char **argv) {
 				result=STATE_CRITICAL;
 			else if (check_warning_value==TRUE && percent_non_purgeable_space >= warning_value)
 				result=STATE_WARNING;
-			purgeable_disk_space/=1024;
 			xasprintf (&output_message,_("%lu MB (%lu%%) not yet purgeable on volume %s"),non_purgeable_disk_space,percent_non_purgeable_space,volume_name);
 		}
 

--- a/plugins/check_real.c
+++ b/plugins/check_real.c
@@ -95,22 +95,24 @@ main (int argc, char **argv)
 
 	/* send the OPTIONS request */
 	sprintf (buffer, "OPTIONS rtsp://%s:%d RTSP/1.0\r\n", host_name, server_port);
-	result = send (sd, buffer, strlen (buffer), 0);
+	if (send (sd, buffer, strlen (buffer), 0) == -1)
+		die (STATE_CRITICAL, _("Can not send data to %s\n"), host_name);
 
 	/* send the header sync */
 	sprintf (buffer, "CSeq: 1\r\n");
-	result = send (sd, buffer, strlen (buffer), 0);
+	if (send (sd, buffer, strlen (buffer), 0) == -1)
+		die (STATE_CRITICAL, _("Can not send data to %s\n"), host_name);
 
 	/* send a newline so the server knows we're done with the request */
 	sprintf (buffer, "\r\n");
-	result = send (sd, buffer, strlen (buffer), 0);
+	if (send (sd, buffer, strlen (buffer), 0) == -1)
+		die (STATE_CRITICAL, _("Can not send data to %s\n"), host_name);
 
 	/* watch for the REAL connection string */
-	result = recv (sd, buffer, MAX_INPUT_BUFFER - 1, 0);
-
-	/* return a CRITICAL status if we couldn't read any data */
-	if (result == -1)
+	if (recv (sd, buffer, MAX_INPUT_BUFFER - 1, 0) == -1) {
+		/* return a CRITICAL status if we couldn't read any data */
 		die (STATE_CRITICAL, _("No data received from %s\n"), host_name);
+	}
 
 	/* make sure we find the response we are looking for */
 	if (!strstr (buffer, server_expect)) {
@@ -124,8 +126,6 @@ main (int argc, char **argv)
 		/* else we got the REAL string, so check the return code */
 
 		time (&end_time);
-
-		result = STATE_OK;
 
 		status_line = (char *) strtok (buffer, "\n");
 
@@ -159,22 +159,25 @@ main (int argc, char **argv)
 	}
 
 	/* Part II - Check stream exists and is ok */
-	if ((result == STATE_OK )&& (server_url != NULL) ) {
+	if ((result == STATE_OK ) && (server_url != NULL) ) {
 
 		/* Part I - Server Check */
 
 		/* send the DESCRIBE request */
 		sprintf (buffer, "DESCRIBE rtsp://%s:%d%s RTSP/1.0\r\n", host_name,
 						 server_port, server_url);
-		result = send (sd, buffer, strlen (buffer), 0);
+		if (send (sd, buffer, strlen (buffer), 0) == -1)
+			die (STATE_CRITICAL, _("Can not send data to %s\n"), host_name);
 
 		/* send the header sync */
 		sprintf (buffer, "CSeq: 2\r\n");
-		result = send (sd, buffer, strlen (buffer), 0);
+		if (send (sd, buffer, strlen (buffer), 0) == -1)
+			die (STATE_CRITICAL, _("Can not send data to %s\n"), host_name);
 
 		/* send a newline so the server knows we're done with the request */
 		sprintf (buffer, "\r\n");
-		result = send (sd, buffer, strlen (buffer), 0);
+		if (send (sd, buffer, strlen (buffer), 0) == -1)
+			die (STATE_CRITICAL, _("Can not send data to %s\n"), host_name);
 
 		/* watch for the REAL connection string */
 		result = recv (sd, buffer, MAX_INPUT_BUFFER - 1, 0);
@@ -199,8 +202,6 @@ main (int argc, char **argv)
 				/* else we got the REAL string, so check the return code */
 
 				time (&end_time);
-
-				result = STATE_OK;
 
 				status_line = (char *) strtok (buffer, "\n");
 

--- a/plugins/check_uptime.c
+++ b/plugins/check_uptime.c
@@ -180,7 +180,6 @@ static int process_arguments (int argc, char **argv) {
 			} // end case
 		} // end while
 
-	c = optind;
 	set_thresholds(&my_thresholds, warning, critical);
 	return validate_arguments ();
 

--- a/plugins/netutils.c
+++ b/plugins/netutils.c
@@ -160,8 +160,6 @@ process_request (const char *server_address, int server_port, int proto,
 	int result;
 	int sd;
 
-	result = STATE_OK;
-
 	result = np_net_connect (server_address, server_port, &sd, proto);
 	if (result != STATE_OK)
 		return STATE_CRITICAL;


### PR DESCRIPTION
This pull request fix almost all the Clang warnings `Dead assignment`.
Command Line: 

``` sh
make 'CFLAGS=-Wall -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security'
```

Clang Version:  `clang version 3.8.0 (tags/RELEASE_380/final)`
