### PR TITLE
Don’t prematurely report success when checking HTTP TLS cert validity

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1023,9 +1023,11 @@ check_http (void)
     elapsed_time_ssl = (double)microsec_ssl / 1.0e6;
     if (check_cert == TRUE) {
       result = np_net_ssl_check_cert(days_till_exp_warn, days_till_exp_crit);
-      np_net_ssl_cleanup();
-      if (sd) close(sd);
-      return result;
+      if (result != STATE_OK) {
+        np_net_ssl_cleanup();
+        if (sd) close(sd);
+        return result;
+      }
     }
   }
 #endif /* HAVE_SSL */

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -304,7 +304,8 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 		else
 			status = STATE_CRITICAL;
 	} else {
-		printf(_("OK - Certificate '%s' will expire on %s.\n"), cn, timestamp);
+		// Do not print a newline - further check output from check_http/tcp will follow.
+		printf(_("OK - Certificate '%s' will expire on %s. "), cn, timestamp);
 		status = STATE_OK;
 	}
 	X509_free(certificate);

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -211,6 +211,9 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 	int time_remaining;
 	time_t tm_t;
 
+	// Prefix whatever we're about to print with SSL.
+	printf("SSL ");
+
 	certificate=SSL_get_peer_certificate(s);
 	if (!certificate) {
 		printf("%s\n",_("CRITICAL - Cannot retrieve server certificate."));


### PR DESCRIPTION
As it stands, if you specify `-C ...` to check certificate validity with `check_http`, all other conditions are ignored. The server could drop the connection immediately after the TLS handshake, and the "HTTP check" would still succeed. This is different from the standard conjunctive nature of check conditions, and is not documented as such, so it's quite a gotcha: a service could be 100% dead and this check would still be green.

Before (check expects 200, would get 403, still succeeds):
```
check_http 104.20.4.224 --sni --ssl -C 30 --expect 200; echo $?
OK - Certificate 'ssl439398.cloudflaressl.com' will expire on 2017-06-08 19:59 -0400/EDT.
0
```

After (check expects 200, gets 403, fails as expected):
```
check_http 104.20.4.224 --sni --ssl -C 30 --expect 200; echo $?
SSL OK - Certificate 'ssl439398.cloudflaressl.com' will expire on 2017-06-08 19:59 -0400/EDT. HTTP CRITICAL - Invalid HTTP response received from host on port 443: HTTP/1.1 403 Forbidden
2
```

As above, this change also tweaks the output format: The SSL status is prefixed with "SSL" to make it more obvious that the SSL state is separate from the HTTP state. The two status messages also now appear on the same line, so that they're sure to make it into `$SERVICESTATUS$` (rather than just the SSL status, which may not be the cause of the failure). These output changes also apply to check_tcp. If grepping check_http/tcp output with line-start anchors is a common practice, it might be a good idea not to make these changes and to keep the current behaviour. 

This is a breaking change, in that anyone who upgrades will immediately discover which checks have been reporting false positives for the last however-long.