### PR TITLE
de,fr.po: fix syntax errors end-of-line within string.

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: nagiosplug\n"
+"Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: devel@nagios-plugins.org\n"
 "POT-Creation-Date: 2010-07-09 19:30-0400\n"
 "PO-Revision-Date: 2004-12-23 17:46+0100\n"
@@ -1485,7 +1485,7 @@ msgid "(fully qualified domain name) as the [host_name] argument."
 msgstr ""
 
 #: plugins/check_http.c:1408
-msgid ""You may also need to give a FQDN or IP address using -I (or --IP-Address)."
+msgid "You may also need to give a FQDN or IP address using -I (or --IP-Address)."
 msgstr ""
 
 #: plugins/check_http.c:1411

--- a/po/fr.po
+++ b/po/fr.po
@@ -1526,7 +1526,7 @@ msgid "(fully qualified domain name) as the [host_name] argument."
 msgstr ""
 
 #: plugins/check_http.c:1408
-msgid ""You may also need to give a FQDN or IP address using -I (or --IP-Address)."
+msgid "You may also need to give a FQDN or IP address using -I (or --IP-Address)."
 msgstr ""
 
 #: plugins/check_http.c:1411


### PR DESCRIPTION
I am fixing two errors and one warning at compilation time.
```
rm -f de.gmo && /usr/bin/msgfmt -c --statistics -o de.gmo de.po
de.po:1488: keyword "You" unknown
de.po:1488:12: syntax error
de.po:1489: end-of-line within string
```
and
```
de.po:9: warning: header field 'Language' missing in header
```