### PR TITLE
Update check_file_age.pl

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -77,8 +77,6 @@ if (! $opt_f) {
 	exit $ERRORS{'UNKNOWN'};
 }
 
-$opt_f = '"' . $opt_f . '"';
-
 # Check that file(s) exists (can be directory or link)
 $perfdata = "";
 $output = "";


### PR DESCRIPTION
Reverted latest change because this broke the plugin. (File not found for every file)
The plugin does handle whitespaces, but you need to correctly quote the input. See example:
/usr/lib64/nagios/plugins/check_file_age -f "'/tmp/test 2'"
FILE_AGE OK: /tmp/test 2 is 17 seconds old and 0 bytes  | age=17s;240;600 size=0B;0;0;0