### PR TITLE
The adding of quotes breaks file checking

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -77,8 +77,6 @@ if (! $opt_f) {
 	exit $ERRORS{'UNKNOWN'};
 }
 
-$opt_f = '"' . $opt_f . '"';
-
 # Check that file(s) exists (can be directory or link)
 $perfdata = "";
 $output = "";


### PR DESCRIPTION
When checking the file /this (which does exist), the system calls made are:
lstat("\"/this\"", 0x7ffd44e6cba0)      = -1 ENOENT (No such file or directory)
stat("\"/this\"", 0x1555130)            = -1 ENOENT (No such file or directory)

fixed if this line is removed.