### PR TITLE
Allow check_users thresholds to be zero

### DIFF
--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -222,10 +222,10 @@ process_arguments (int argc, char **argv)
 	/* this will abort in case of invalid ranges */
 	set_thresholds (&thlds, warning_range, critical_range);
 
-	if (thlds->warning->end <= 0)
-		usage4 (_("Warning threshold must be a positive integer"));
-	if (thlds->critical->end <= 0)
-		usage4 (_("Critical threshold must be a positive integer"));
+	if (thlds->warning && thlds->warning->end < 0)
+		usage4 (_("Warning threshold must be a non-negative integer"));
+	if (thlds->critical && thlds->critical->end < 0)
+		usage4 (_("Critical threshold must be a non-negative integer"));
 
 	return OK;
 }


### PR DESCRIPTION
For years we've been using the check_users plugin with long delays in Nagios and a warn/crit threshold of zero, to ensure that we don't leave ourselves logged in to a particular set of servers for too long. With the latest update to check_users, these tests stopped working.

I don't see any reason for not allowing these thresholds to be zero, this PR changes the validation to allow it.

I've also stopped the plugin segfaulting if only one of the two thresholds are provided.