### PR TITLE
Move uptime to the metric_count[]

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -66,17 +66,18 @@ int verbose = 0;
 static double warning_time = 0;
 static double critical_time = 0;
 
-#define LENGTH_METRIC_UNIT 6
+#define LENGTH_METRIC_UNIT 7
 static const char *metric_unit[LENGTH_METRIC_UNIT] = {
-	"Open_files",
+	"x",
 	"Open_tables",
 	"Qcache_free_memory",
 	"Qcache_queries_in_cache",
 	"Threads_connected",
 	"Threads_running"
+	"Uptime"
 };
 
-#define LENGTH_METRIC_COUNTER 9
+#define LENGTH_METRIC_COUNTER 8
 static const char *metric_counter[LENGTH_METRIC_COUNTER] = {
 	"Connections",
 	"Qcache_hits",
@@ -86,7 +87,6 @@ static const char *metric_counter[LENGTH_METRIC_COUNTER] = {
 	"Queries",
 	"Questions",
 	"Table_locks_waited",
-	"Uptime"
 };
 
 thresholds *my_threshold = NULL;


### PR DESCRIPTION
this commit moves the uptime metric from metric_counter[] to metric_unit[] in check_mysql check.
This allows for the uptime performance data to be grpaphed and have an actual picture when your mysql restarts
and how many times.