### PR TITLE
check_file_age: fix check for multiple files

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -81,6 +81,7 @@ $opt_f = '"' . $opt_f . '"' if $opt_f =~ / /;
 
 # Check that file(s) exists (can be directory or link)
 $perfdata = "";
+$result = 'OK';
 $output = "";
 @filelist = glob($opt_f);
 
@@ -100,19 +101,25 @@ foreach $filename (@filelist) {
 	$st = File::stat::stat($filename);
 	$age = time - $st->mtime;
 	$size = $st->size;
-	$perfdata = $perfdata . "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0 ";
-
-	$result = 'OK';
 
 	if (($opt_c and $age > $opt_c) or ($opt_C and $size < $opt_C)) {
 		$result = 'CRITICAL';
+		$output = "FILE_AGE $result: $filename is $age seconds old and $size bytes";
+		$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0";
+		last;
 	}
 	elsif (($opt_w and $age > $opt_w) or ($opt_W and $size < $opt_W)) {
 		$result = 'WARNING';
+		$output = "FILE_AGE $result: $filename is $age seconds old and $size bytes";
+		$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0";
+		last;
 	}
 
-	$output = $output . "FILE_AGE $result: $filename is $age seconds old and $size bytes ";
+	$output = "FILE_AGE $result: $filename is $age seconds old and $size bytes"
+		unless length $output;
 
+	$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0"
+		unless length $perfdata;
 }
 
 print "$output | $perfdata\n";


### PR DESCRIPTION
Without this, the script would always return the result for the last
checked file, if we check multiple files (e.g a directory).

We now return WARNING/CRITICAL for the first file which violates the
thresholds, and returnung the perf data for this file.

If all files are OK, we return only OK with the perf data of the first
file found. I don't added the filenames here, because if we check a
directory with many files, it don't makes sense to me to put all filename
in the check results.