### PR TITLE
check_http: fix parsing the last header

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -750,7 +750,8 @@ header_value (const char *headers, const char *header)
 
   value_end = strchr(s, '\r');
   if (!value_end) {
-      die (STATE_UNKNOWN, _("HTTP_UNKNOWN - Failed to parse response headers\n"));
+      // Turns out there's no newline after the header... So it's at the end!
+      value_end = s + strlen(s);
   }
 
   value_size = value_end - s;


### PR DESCRIPTION
The header that has no newline trailing it, is the last header.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>