### PR TITLE
fix configure.ac for FreeBSD SWAPFORMAT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1602,7 +1602,7 @@ then
 
 	if [$PATH_TO_SWAPINFO -k 2>/dev/null | egrep -i "^Device +1K-blocks +Used +Avail" >/dev/null]
 	then
-		ac_cv_swap_format=["%*s %f %*d %f"]
+		ac_cv_swap_format=["%*s %lf %*d %lf"]
 		ac_cv_swap_conv=1024
 		AC_MSG_RESULT([using FreeBSD format swapinfo])
 	fi


### PR DESCRIPTION
check_swap.c has been switched to double for dsktotal_mb,dskfree_mb
(commit 39c5e4ed595cfbda7cff566575fc5a53252f09b5)

The corresponding sscanf uses SWAP_FORMAT from configure:
        ac_cv_swap_format="%*s %f %*d %f"

With doubles this now has to be:
        ac_cv_swap_format="%*s %lf %*d %lf"