### PR TITLE
m4/ax_with_python.m4: don't crash on version test with python-3.x.

### DIFF
--- a/m4/ax_with_python.m4
+++ b/m4/ax_with_python.m4
@@ -46,7 +46,7 @@ AC_DEFUN([AX_WITH_PYTHON],
     if test "$PYTHON" != "m4_ifval([$2],[$2],[python])"
     then
       AC_MSG_CHECKING($PYTHON version >= $1)
-      if test `$PYTHON -c ["import sys; print sys.version[:3] >= \"$1\" and \"OK\" or \"OLD\""]` = "OK"
+      if test `$PYTHON -c ["import sys; print(sys.version[:3] >= \"$1\" and \"OK\" or \"OLD\")"]` = "OK"
       then
         AC_MSG_RESULT(ok)
       else


### PR DESCRIPTION
This macro tests for a version of python greater than or equal to
2.6. To do that, it checks the python version (from within python) and
then then calls python's "print" function to output whether or not the
result is satisfactory. In python-2.x, this works fine; but in
python-3.x, the syntax of the "print" function has changed -- it now
requires parentheses. The result is that when the user has python-3.x
as his default interpreter, he sees the following error:
```
  File "<string>", line 1
      import sys; print sys.version[:3] >= "2.6" and "OK" or "OLD"
                          ^
  SyntaxError: invalid syntax
```
Fortunately, the parentheses also work in python-2.x, so their
addition is backwards-compatible. This commit adds the parentheses to
the version check, and allows it to work with both major versions of
python.