### PR TITLE
Partial revert "fix check_http - was having constant socket timeouts"

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -703,8 +703,10 @@ int chunk_header(char **buf)
         ++*buf;
 
     // soak up the leading CRLF
-    while (**buf != '\0' && (**buf == '\r' || **buf == '\n'))
-        ++*buf;
+    if (**buf && **buf == '\r' && *(++*buf) && **buf == '\n')
+      ++*buf;
+    else
+      die (STATE_UNKNOWN, _("HTTP UNKNOWN - Failed to parse chunked body, invalid format\n"));
 
     return lth;
 }


### PR DESCRIPTION
This partially reverts changes applied by commit 2b38350d546ef9632ccd90e300eeaf6eda0ca32c

The mechanism brokes if there are CRs or LFs following the chunk header.
So I reverted it to the previous version.