### PR TITLE
plugins/common.h: Set default MySQL port

### DIFF
--- a/plugins/common.h
+++ b/plugins/common.h
@@ -168,6 +168,11 @@
 #  endif
 #endif
 
+/* MariaDB 10.2 client does not set MYSQL_PORT */
+#ifndef MYSQL_PORT
+#  define MYSQL_PORT 3306
+#endif
+
 /*
  *
  * Standard Values


### PR DESCRIPTION
As of MariaDB 10.2 the headers for client no longer set the
default MySQL port. Patch fixes this for any version of MariaDB
or MySQL into the future.

See also: https://bugs.freebsd.org/223387