### PR TITLE
Fix Issue #309

### DIFF
--- a/lib/utils_disk.h
+++ b/lib/utils_disk.h
@@ -26,7 +26,7 @@ struct parameter_list
   struct parameter_list *name_next;
   uintmax_t total, available, available_to_root, used, inodes_free, inodes_total;
   double dfree_pct, dused_pct;
-  double dused_units, dfree_units, dtotal_units;
+  uintmax_t dused_units, dfree_units, dtotal_units;
   double dused_inodes_percent, dfree_inodes_percent;
 };
 


### PR DESCRIPTION
Fix issue "check_disk fails on large unix filesystems". 

Variable definition "double" for "dused_units, dfree_units and dtotal_units"  was insufficient to represent large free disk space ( ~8TB) and was changed to uintmax_t.

Local test was successfull:
/opt/freeware/lib/icinga/plugins/check_disk -l -e -c 5% -K 10% -p '/test'
DISK OK| /test=8482253MB;;15921817;0;16759808
