### PR TITLE
check_swap.c: Add --no-swap flag

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ This file documents the major additions and syntax changes between releases.
 	check_ldap: Add support for checking LDAP cert age (Guillaume Rousse)
 	check_icmp: Add Jitter, MOS, Score (Alessandro Ren)
 	check_radius: Add calling-station-id (cejkar)
+	check_swap: Add --no-swap flag (Mario Trangoni)
 	ssl_utils: Added certificate expiry data in OK status (check_http, check_smtp, check_tcp) (Matt Capra)
 
 


### PR DESCRIPTION
PR for issue #366.

This allow handling the state in case of no swap configured/available.
By default it remains in at critical state.

See,
```
# free -g
              total        used        free      shared  buff/cache   available
Mem:            251          35         147           0          68         214
Swap:             0           0           0

# ./check_swap --warning=25%%
SWAP CRITICAL - 0% free (0 MB out of 0 MB) - Swap is either disabled, not present, or of zero size. |swap=0MB;0;0;0;0
# echo $?
2

# ./check_swap --warning=25%% -n ok
SWAP OK - 0% free (0 MB out of 0 MB) - Swap is either disabled, not present, or of zero size. |swap=0MB;0;0;0;0
# echo $?
0

# ./check_swap --warning=25%% --no-swap=warning
SWAP WARNING - 0% free (0 MB out of 0 MB) - Swap is either disabled, not present, or of zero size. |swap=0MB;0;0;0;0
# echo $?
1
```

Thanks!