### PR TITLE
handle errors in "grep -c"

### DIFF
--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -204,8 +204,12 @@ fi
 
 diff "$logfile" "$oldlog" | grep -v "^>" > "$tempdiff"
 
-# Count the number of matching log entries we have
-count=$(grep -c "$query" "$tempdiff")
+# Count the number of matching log entries we have and handle errors when grep fails
+count=$(grep -c "$query" "$tempdiff" 2>&1)
+if [[ $? -gt 1 ]];then
+    echo "Log check error: $count"
+    exit "$STATE_UNKNOWN"
+fi
 
 # Get the last matching entry in the diff file
 lastentry=$(grep "$query" "$tempdiff" | tail -1)


### PR DESCRIPTION
This script returns with critical status and message "()" when the previous "diff" or "grep" fails. 
Because the case, if $count is not numeric (e.g. empty), will not be handled correctly.

This fix handle errors in "grep -c", e.g. if the file not exists, and return with Unknown status and stderr message.

Example
Log check error: grep: can't open /tmp/check_log.002330