### PR TITLE
Fixed xasprintf segfault due to %f being used instead of %i

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -28,7 +28,7 @@
 
 const char *progname = "check_disk";
 const char *program_name = "check_disk";  /* Required for coreutils libs */
-const char *copyright = "1999-2014";
+const char *copyright = "1999-2018";
 const char *email = "devel@nagios-plugins.org";
 
 
@@ -315,7 +315,7 @@ main (int argc, char **argv)
       get_stats (path, &fsp);
 
       if (verbose >= 3) {
-        printf ("For %s, used_pct=%g free_pct=%g used_units=%g free_units=%g total_units=%g used_inodes_pct=%g free_inodes_pct=%g fsp.fsu_blocksize=%llu mult=%llu\n",
+        printf ("For %s, used_pct=%g free_pct=%g used_units=%i free_units=%i total_units=%i used_inodes_pct=%g free_inodes_pct=%g fsp.fsu_blocksize=%llu mult=%llu\n",
           me->me_mountdir, path->dused_pct, path->dfree_pct, path->dused_units, path->dfree_units, path->dtotal_units, path->dused_inodes_percent, path->dfree_inodes_percent, fsp.fsu_blocksize, mult);
       }
 
@@ -384,7 +384,7 @@ main (int argc, char **argv)
       if (disk_result==STATE_OK && erronly && !verbose)
         continue;
 
-      xasprintf (&output, "%s%s%s%s %.0f %s (%.2f%%",
+      xasprintf (&output, "%s%s%s%s %i %s (%.2f%%",
                 output,
                 newlines ? "" : " ",
                 status_lit,
@@ -1004,7 +1004,7 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
         get_fs_usage (p_list->best_match->me_mountdir, p_list->best_match->me_devname, &tmpfsp);
         get_path_stats(p_list, &tmpfsp); 
         if (verbose >= 3)
-          printf("Group %s: adding %llu blocks sized %llu, (%s) used_units=%g free_units=%g total_units=%g fsu_blocksize=%llu mult=%llu\n",
+          printf("Group %s: adding %llu blocks sized %llu, (%s) used_units=%i free_units=%i total_units=%i fsu_blocksize=%llu mult=%llu\n",
                  p_list->group, tmpfsp.fsu_bavail, tmpfsp.fsu_blocksize, p_list->best_match->me_mountdir, p_list->dused_units, p_list->dfree_units,
                  p_list->dtotal_units, mult);
 
@@ -1025,7 +1025,7 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
         first = 0;
       }
       if (verbose >= 3) 
-        printf("Group %s now has: used_units=%g free_units=%g total_units=%g fsu_blocksize=%llu mult=%llu\n",
+        printf("Group %s now has: used_units=%1 free_units=%1 total_units=%1 fsu_blocksize=%llu mult=%llu\n",
                p->group, tmpfsp.fsu_bavail, tmpfsp.fsu_blocksize, p->best_match->me_mountdir, p->dused_units,
                p->dfree_units, p->dtotal_units, mult);
     }


### PR DESCRIPTION
When testing the maint branch I found that `check_disk` was getting a segfault. I ended up changing `%.0f` to `%i` to resolve the issue. I also changed some of the verbose printf statements from `%g` to `%i` to keep it consistent.