### PR TITLE
check_dns: make reverse (PTR) check case insensitive

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -288,7 +288,7 @@ main (int argc, char **argv)
     temp_buffer = "";
     for (i=0; i<expected_address_cnt; i++) {
       /* check if we get a match and prepare an error string */
-      if (strcmp(address, expected_address[i]) == 0) result = STATE_OK;
+      if (strcasecmp(address, expected_address[i]) == 0) result = STATE_OK;
       xasprintf(&temp_buffer, "%s%s; ", temp_buffer, expected_address[i]);
     }
     if (result == STATE_CRITICAL) {


### PR DESCRIPTION
check_dns: reverse (IP to Hostname)

DNS is not case sensitive!


Old:

`./check_dns -H 192.168.178.1 -a "name = fRitZ.BoX."`

**DNS CRITICAL - expected 'name = fRitZ.BoX.' but got 'name = fritz.box.'**

New:

`./check_dns -H 192.168.178.1 -a "name = fRitZ.BoX."`

**DNS OK: 0.144 seconds response time.  192.168.178.1 returns name = fritz.box.**