### PR TITLE
Issue #422 - added binary units (KiB, MiB, GiB, TiB) and corrected decimal units (kB, MB, GB, TB) in check_disk

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -581,6 +581,18 @@ process_arguments (int argc, char **argv)
       } else if (! strcmp (optarg, "TB")) {
         mult = (uintmax_t)1024 * 1024 * 1024 * 1024;
         units = strdup ("TB");
+      } else if (! strcmp (optarg, "KiB")) {
+        mult = (uintmax_t)1000;
+        units = strdup ("KiB");
+      } else if (! strcmp (optarg, "MiB")) {
+        mult = (uintmax_t)1000 * 1000;
+        units = strdup ("MiB");
+      } else if (! strcmp (optarg, "GiB")) {
+        mult = (uintmax_t)1000 * 1000 * 1000;
+        units = strdup ("GiB");
+      } else if (! strcmp (optarg, "TiB")) {
+        mult = (uintmax_t)1000 * 1000 * 1000 * 1000;
+        units = strdup ("TiB");
       } else {
         die (STATE_UNKNOWN, _("unit type %s not known\n"), optarg);
       }
@@ -951,7 +963,7 @@ print_help (void)
   printf ("    %s\n", _("Regular expression to ignore selected path or partition (may be repeated)"));
   printf (UT_PLUG_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
   printf (" %s\n", "-u, --units=STRING");
-  printf ("    %s\n", _("Choose bytes, kB, MB, GB, TB (default: MB)"));
+  printf ("    %s\n", _("Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"));
   printf (UT_VERBOSE);
   printf (" %s\n", "-X, --exclude-type=TYPE");
   printf ("    %s\n", _("Ignore all filesystems of indicated type (may be repeated)"));

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -570,28 +570,28 @@ process_arguments (int argc, char **argv)
         mult = (uintmax_t)1;
         units = strdup ("B");
       } else if (! strcmp (optarg, "kB")) {
-        mult = (uintmax_t)1024;
+        mult = (uintmax_t)1000;
         units = strdup ("kB");
       } else if (! strcmp (optarg, "MB")) {
-        mult = (uintmax_t)1024 * 1024;
+        mult = (uintmax_t)1000 * 1000;
         units = strdup ("MB");
       } else if (! strcmp (optarg, "GB")) {
-        mult = (uintmax_t)1024 * 1024 * 1024;
+        mult = (uintmax_t)1000 * 1000 * 100;
         units = strdup ("GB");
       } else if (! strcmp (optarg, "TB")) {
-        mult = (uintmax_t)1024 * 1024 * 1024 * 1024;
+        mult = (uintmax_t)1000 * 1000 * 1000 * 1000;
         units = strdup ("TB");
       } else if (! strcmp (optarg, "KiB")) {
-        mult = (uintmax_t)1000;
+        mult = (uintmax_t)1024;
         units = strdup ("KiB");
       } else if (! strcmp (optarg, "MiB")) {
-        mult = (uintmax_t)1000 * 1000;
+        mult = (uintmax_t)1024 * 1024;
         units = strdup ("MiB");
       } else if (! strcmp (optarg, "GiB")) {
-        mult = (uintmax_t)1000 * 1000 * 1000;
+        mult = (uintmax_t)1024 * 1024 * 1024;
         units = strdup ("GiB");
       } else if (! strcmp (optarg, "TiB")) {
-        mult = (uintmax_t)1000 * 1000 * 1000 * 1000;
+        mult = (uintmax_t)1024 * 1024 * 1024 * 1024;
         units = strdup ("TiB");
       } else {
         die (STATE_UNKNOWN, _("unit type %s not known\n"), optarg);
@@ -600,13 +600,13 @@ process_arguments (int argc, char **argv)
         die (STATE_UNKNOWN, _("failed allocating storage for '%s'\n"), "units");
       break;
     case 'k': /* display mountpoint */
-      mult = 1024;
+      mult = 1000;
       if (units)
         free(units);
       units = strdup ("kB");
       break;
     case 'm': /* display mountpoint */
-      mult = 1024 * 1024;
+      mult = 1000 * 1000;
       if (units)
         free(units);
       units = strdup ("MB");
@@ -815,7 +815,7 @@ process_arguments (int argc, char **argv)
   }
 
   if (units == NULL) {
-    units = strdup ("MB");
+    units = strdup ("MiB");
     mult = (uintmax_t)1024 * 1024;
   }
 
@@ -963,7 +963,7 @@ print_help (void)
   printf ("    %s\n", _("Regular expression to ignore selected path or partition (may be repeated)"));
   printf (UT_PLUG_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
   printf (" %s\n", "-u, --units=STRING");
-  printf ("    %s\n", _("Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"));
+  printf ("    %s\n", _("Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MiB)"));
   printf (UT_VERBOSE);
   printf (" %s\n", "-X, --exclude-type=TYPE");
   printf ("    %s\n", _("Ignore all filesystems of indicated type (may be repeated)"));

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -576,7 +576,7 @@ process_arguments (int argc, char **argv)
         mult = (uintmax_t)1000 * 1000;
         units = strdup ("MB");
       } else if (! strcmp (optarg, "GB")) {
-        mult = (uintmax_t)1000 * 1000 * 100;
+        mult = (uintmax_t)1000 * 1000 * 1000;
         units = strdup ("GB");
       } else if (! strcmp (optarg, "TB")) {
         mult = (uintmax_t)1000 * 1000 * 1000 * 1000;

--- a/po/de.po
+++ b/po/de.po
@@ -566,7 +566,7 @@ msgid ""
 msgstr ""
 
 #: plugins/check_disk.c:957
-msgid "Choose bytes, kB, MB, GB, TB (default: MB)"
+msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"
 msgstr ""
 
 #: plugins/check_disk.c:960

--- a/po/de.po
+++ b/po/de.po
@@ -566,7 +566,7 @@ msgid ""
 msgstr ""
 
 #: plugins/check_disk.c:957
-msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"
+msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MiB)"
 msgstr ""
 
 #: plugins/check_disk.c:960

--- a/po/fr.po
+++ b/po/fr.po
@@ -577,8 +577,8 @@ msgstr ""
 "être utilisé plusieurs fois)"
 
 #: plugins/check_disk.c:957
-msgid "Choose bytes, kB, MB, GB, TB (default: MB)"
-msgstr "Choisissez octets, kb, MB, GB, TB (par défaut: MB)"
+msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"
+msgstr "Choisissez octets, kb, MB, GB, TB, KiB, MiB, GiB, TiB (par défaut: MB)"
 
 #: plugins/check_disk.c:960
 msgid "Ignore all filesystems of indicated type (may be repeated)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -577,7 +577,7 @@ msgstr ""
 "être utilisé plusieurs fois)"
 
 #: plugins/check_disk.c:957
-msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"
+msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MiB)"
 msgstr "Choisissez octets, kb, MB, GB, TB, KiB, MiB, GiB, TiB (par défaut: MB)"
 
 #: plugins/check_disk.c:960

--- a/po/nagios-plugins.pot
+++ b/po/nagios-plugins.pot
@@ -545,7 +545,7 @@ msgid ""
 msgstr ""
 
 #: plugins/check_disk.c:899
-msgid "Choose bytes, kB, MB, GB, TB (default: MB)"
+msgid "Choose bytes, kB, MB, GB, TB, KiB, MiB, GiB, TiB (default: MB)"
 msgstr ""
 
 #: plugins/check_disk.c:902


### PR DESCRIPTION
In release 2.2.1 (and earlier) check_disk doesn't support binary units (KiB, MiB, GiB, TiB). However, the SI-units are interpreted as binary units.

In this commit the following has been implemented:

1. added KiB, MiB, GiB, TiB as binary units to check_disk (plugins/check_disk.c#584-595)
2. corrected mult for kB, MB, GB, TB to decimal values (plugins/check_disk.c#573-582)
3. changed default unit from MB to MiB (plugins/check_disk.c#818,966)
4. change mult for args -k and -kilobyte (plugins/check_disk.c#603)
5. change mult for args -m and -megabyte (plugins/check_disk.c#609)
6. changed corresponding texts in language files (po/de.po#569, po/fr.po#580-581, po/nagios_plugins.pot#548)

Point 3 is changed to MiB to keep numbers identical, but unit will changes. 
Point 4 and 5 will cause different values (percentages will remain the same), but the units are kept the same, because of the longops. 
