### PR TITLE
check_smtp: Add option to prefix PROXY header

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,7 @@ This file documents the major additions and syntax changes between releases.
 	check_radius: Add calling-station-id (cejkar)
 	check_swap: Add --no-swap flag (Mario Trangoni)
 	ssl_utils: Added certificate expiry data in OK status (check_http, check_smtp, check_tcp) (Matt Capra)
+	check_smtp: Add --proxy flag for PROXY protocol (Patrick Uiterwijk)
 
 
 2.2.2 xxxx-xx-xx

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -52,6 +52,7 @@ int days_till_exp_warn, days_till_exp_crit;
 enum {
 	SMTP_PORT	= 25
 };
+#define PROXY_PREFIX "PROXY TCP4 0.0.0.0 0.0.0.0 25 25\r\n"
 #define SMTP_EXPECT "220"
 #define SMTP_HELO "HELO "
 #define SMTP_EHLO "EHLO "
@@ -106,6 +107,7 @@ double critical_time = 0;
 int check_critical_time = FALSE;
 int verbose = 0;
 int use_ssl = FALSE;
+short use_proxy_prefix = FALSE;
 short use_ehlo = FALSE;
 short use_lhlo = FALSE;
 short ssl_established = 0;
@@ -196,6 +198,13 @@ main (int argc, char **argv)
 	result = my_tcp_connect (server_address, server_port, &sd);
 
 	if (result == STATE_OK) { /* we connected */
+
+		/* If requested, send PROXY header */
+		if (use_proxy_prefix) {
+			if (verbose)
+				printf ("Sending header %s\n", PROXY_PREFIX);
+			send(sd, PROXY_PREFIX, strlen(PROXY_PREFIX), 0);
+		}
 
 		/* watch for the SMTP connection string and */
 		/* return a WARNING status if we couldn't read any data */
@@ -484,6 +493,7 @@ process_arguments (int argc, char **argv)
 		{"starttls",no_argument,0,'S'},
 		{"certificate",required_argument,0,'D'},
 		{"ignore-quit-failure",no_argument,0,'q'},
+		{"proxy",no_argument,0,'r'},
 		{0, 0, 0, 0}
 	};
 
@@ -500,7 +510,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "+hVv46Lt:p:f:e:c:w:H:C:R:SD:F:A:U:P:q",
+		c = getopt_long (argc, argv, "+hVv46Lrt:p:f:e:c:w:H:C:R:SD:F:A:U:P:q",
 		                 longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -621,6 +631,9 @@ process_arguments (int argc, char **argv)
 		/* starttls */
 			use_ssl = TRUE;
 			use_ehlo = TRUE;
+			break;
+		case 'r':
+			use_proxy_prefix = TRUE;
 			break;
 		case 'L':
 			use_lhlo = TRUE;
@@ -820,6 +833,8 @@ print_help (void)
   printf ("    %s\n", _("FROM-address to include in MAIL command, required by Exchange 2000")),
   printf (" %s\n", "-F, --fqdn=STRING");
   printf ("    %s\n", _("FQDN used for HELO"));
+  printf (" %s\n", "-r, --proxy");
+  printf ("    %s\n", _("Use PROXY protocol prefix for the connection."));
 #ifdef HAVE_SSL
   printf (" %s\n", "-D, --certificate=INTEGER[,INTEGER]");
   printf ("    %s\n", _("Minimum number of days a certificate has to be valid."));


### PR DESCRIPTION
This enables checks of SMTP servers that expect the haproxy
PROXY protocol:  -o smtpd_upstream_proxy_protocol=haproxy.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>