### PR TITLE
check_oracle: Added support for Oracle 18c XE for --db

### DIFF
--- a/plugins-scripts/check_oracle.sh
+++ b/plugins-scripts/check_oracle.sh
@@ -166,7 +166,7 @@ case "$cmd" in
     }'
     ;;
 --db)
-    pmonchk=$(pgrep -f "(asm|ora)_pmon_${2}$")
+    pmonchk=$(pgrep -f "(asm|ora|xe)_pmon_${2}$")
     if [ "${pmonchk}" -ge 1 ] ; then
         echo "${2} OK - ${pmonchk} PMON process(es) running"
         exit "$STATE_OK"


### PR DESCRIPTION
PMON process of oracle 18c XE is neither prefixed by asm_ nor by ora_ but by xe_