### PR TITLE
Fix for -a input exceeding 384 length, increased to 4096 for searchin…

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -51,7 +51,9 @@ int error_scan (char *);
 void print_help (void);
 void print_usage (void);
 
-#define ADDRESS_LENGTH 384 
+/* Allow up to 4096 input length, this is helpful
+   when the TXT records returned have multiple 255 legth values returned */
+#define ADDRESS_LENGTH 4096
 char query_address[ADDRESS_LENGTH] = "";
 char dns_server[ADDRESS_LENGTH] = "";
 char tmp_dns_server[ADDRESS_LENGTH] = "";


### PR DESCRIPTION
Fix for -a input exceeding 384 length, increased to 4096 for searching multiple 255 length TXT records like DKIM.