### PR TITLE
fix error message when -e <response> fails

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1269,7 +1269,7 @@ check_http (void)
     }
 
     /* Bypass normal status line check if server_expect was set by user and not default */
-    if ( server_expect_yn  )  {
+    if ( server_expect_yn && !bad_response )  {
 
         xasprintf (&msg,
                    _("Status line output matched \"%s\" - "), server_expect);


### PR DESCRIPTION
Old and busted:
./check_http -H slashdot.org -e 666 --ssl
HTTP CRITICAL - Status line output matched "666" - 

New hotness:
./check_http -H slashdot.org -e 666 --ssl
HTTP CRITICAL - Invalid HTTP response received from host on port 443: HTTP/1.1 200 OK
