### PR TITLE
[FR] Make check_file_age.pl use multiline plugin output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ This file documents the major additions and syntax changes between releases.
 	check_disk: Add support for base-10 units kB, MB, GB, TB; rename base-2 units to KiB, MiB, GiB, TiB
 	check_disk_smb: Add configfile feature
 	check_disk_smb: added additional smb support
+	check_file_age: Use extended plugin output to show one file per line
 	check_http: New parameter `--verify-host` will check if -H hostname matches the SSL certificate
 	check_icmp: Add Jitter, MOS, Score (Alessandro Ren)
 	check_ldap: Add support for checking LDAP cert age (Guillaume Rousse)
@@ -36,6 +37,9 @@ This file documents the major additions and syntax changes between releases.
 	check_disk: autofs being mounted despite '-l'. Fixed, and also excluded some system "fake" mountpoints
 	check_dns: Fix for Bind 9.11.x AAAA records being reported with A record format (Troy Lea)
 	check_dns: reverse (PTR) check is now case insensitive
+	check_file_age: For multiple files, use the "worst" status instead of the "last" one
+	check_file_age: perfdata labels when using multiple files
+	check_file_age: For multiple files, don't exit immediately on first file not found
 	check_http: Additional header/status checking
 	check_http: Fix --no-body
 	check_http: When checking certificate, don't check content/status unless specified by --continue-after-certificate

--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -35,7 +35,7 @@ sub print_help ();
 sub print_usage ();
 
 my ($opt_c, $opt_f, $opt_w, $opt_C, $opt_W, $opt_h, $opt_V, $opt_i);
-my ($result, $message, $age, $size, $st, $perfdata, $output, @filelist, $filename);
+my ($result, $message, $age, $size, $st, $perfdata, $output, @filelist, $filename, $counter, $summary, $high_water_mark, $this_level, $this_result);
 
 $PROGNAME="check_file_age";
 
@@ -83,18 +83,38 @@ $opt_f = '"' . $opt_f . '"' if $opt_f =~ / /;
 $perfdata = "";
 $output = "";
 @filelist = glob($opt_f);
+$counter = 0;
+$high_water_mark = 0;
 
+$result = "OK";
 foreach $filename (@filelist) {
 	unless (-e $filename) {
 		if ($opt_i) {
-			$result = 'OK';
-			print "FILE_AGE $result: $filename doesn't exist, but ignore-missing was set\n";
-			exit $ERRORS{$result};
+			if ($output) {
+				$output = $output . "\n";
+			}
+			$output = $output . "FILE_AGE OK: $filename doesn't exist, but ignore-missing was set\n";
+			$this_result = "OK";
+			$this_level = 0;
 
 		} else {
-			print "FILE_AGE CRITICAL: File not found - $filename\n";
-			exit $ERRORS{'CRITICAL'};
+			if ($output) {
+				$output = $output . "\n";
+			}
+			$output = $output . "FILE_AGE CRITICAL: File not found - $filename\n";
+			$this_result = "CRITICAL";
+			$this_level = 2;
 		}
+
+		if ($high_water_mark < $this_level) {
+			$high_water_mark = $this_level;
+			$counter = 1;
+			$result = $this_result;
+		}
+		elsif($high_water_mark = $this_level) {
+			$counter = $counter + 1;
+		}
+		next;
 	}
 
 	$st = File::stat::stat($filename);
@@ -102,20 +122,42 @@ foreach $filename (@filelist) {
 	$size = $st->size;
 	$perfdata = $perfdata . "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0 ";
 
-	$result = 'OK';
+	$this_result = 'OK';
+	$this_level = 0;
 
 	if (($opt_c and $age > $opt_c) or ($opt_C and $size < $opt_C)) {
-		$result = 'CRITICAL';
+		$this_result = 'CRITICAL';
+		$this_level = 2;
 	}
 	elsif (($opt_w and $age > $opt_w) or ($opt_W and $size < $opt_W)) {
-		$result = 'WARNING';
+		$this_result = 'WARNING';
+		$this_level = 1;
 	}
 
-	$output = $output . "FILE_AGE $result: $filename is $age seconds old and $size bytes ";
+	if ($high_water_mark < $this_level) {
+		$high_water_mark = $this_level;
+		$counter = 1;
+		$result = $this_result;
+	}
+	elsif ($high_water_mark == $this_level) {
+		$counter = $counter + 1;
+	}
 
+	if ($output) {
+		$output = $output . "\n";
+	}
+	$output = $output . "FILE_AGE $this_result: $filename is $age seconds old and $size bytes ";
 }
 
-print "$output | $perfdata\n";
+$summary = "$result: $counter files are $result";
+
+if (scalar @filelist == 1) {
+	print "$output | $perfdata \n";
+}
+else {
+	print "$summary \n$output | $perfdata \n";
+}
+
 
 exit $ERRORS{$result};
 

--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -25,6 +25,7 @@ use strict;
 use English;
 use Getopt::Long;
 use File::stat;
+use File::Basename;
 use vars qw($PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
@@ -35,7 +36,7 @@ sub print_help ();
 sub print_usage ();
 
 my ($opt_c, $opt_f, $opt_w, $opt_C, $opt_W, $opt_h, $opt_V, $opt_i);
-my ($result, $message, $age, $size, $st, $perfdata, $output, @filelist, $filename, $counter, $summary, $high_water_mark, $this_level, $this_result);
+my ($result, $message, $age, $size, $st, $perfdata, $output, @filelist, $filename, $safe_filename, $counter, $summary, $high_water_mark, $this_level, $this_result);
 
 $PROGNAME="check_file_age";
 
@@ -120,7 +121,14 @@ foreach $filename (@filelist) {
 	$st = File::stat::stat($filename);
 	$age = time - $st->mtime;
 	$size = $st->size;
-	$perfdata = $perfdata . "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0 ";
+	if (scalar @filelist == 1) {
+		$perfdata = $perfdata . "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0 ";
+	}
+	else {
+		$safe_filename = basename($filename);
+		$safe_filename =~ s/[='"]/_/g;
+		$perfdata = $perfdata . "${safe_filename}_age=${age}s;${opt_w};${opt_c} ${safe_filename}_size=${size}B;${opt_W};${opt_C};0 ";
+	}
 
 	$this_result = 'OK';
 	$this_level = 0;


### PR DESCRIPTION
Fixes #382 and a couple of other issues:
    - Previously, the plugin would exit at the first file not found. This PR has the plugin continue ("`next;`") instead.
    - Previously, the plugin would use the last result rather than the 'worst' result. This PR tracks the highest return level and uses that for plugin output.