### PR TITLE
check_ups: battery runtime left check

### DIFF
--- a/plugins/check_ups.c
+++ b/plugins/check_ups.c
@@ -52,6 +52,7 @@ enum {
 #define UPS_STATUS   4   /* supports UPS status */
 #define UPS_TEMP     8   /* supports UPS temperature */
 #define UPS_LOADPCT	16   /* supports load percent */
+#define UPS_BATTLEFT	32   /* supports runtime left */
 
 #define UPSSTATUS_NONE       0
 #define UPSSTATUS_OFF        1
@@ -86,6 +87,7 @@ double ups_utility_voltage = 0.0;
 double ups_battery_percent = 0.0;
 double ups_load_percent = 0.0;
 double ups_temperature = 0.0;
+double ups_battery_left = 0.0;
 char *ups_status;
 int temp_output_c = 0;
 
@@ -292,12 +294,12 @@ main (int argc, char **argv)
 		if (temp_output_c) {
 		  tunits="degC";
 		  ups_temperature = atof (temp_buffer);
-		  xasprintf (&message, "%sTemp=%3.1fC", message, ups_temperature);
+		  xasprintf (&message, "%sTemp=%3.1fC ", message, ups_temperature);
 		}
 		else {
 		  tunits="degF";
 		  ups_temperature = (atof (temp_buffer) * 1.8) + 32;
-		  xasprintf (&message, "%sTemp=%3.1fF", message, ups_temperature);
+		  xasprintf (&message, "%sTemp=%3.1fF ", message, ups_temperature);
 		}
 
 		if (check_variable == UPS_TEMP) {
@@ -315,6 +317,35 @@ main (int argc, char **argv)
 		} else {
 			xasprintf (&data, "%s %s", data,
 			          fperfdata ("temp", ups_temperature, (extended_units ? tunits : ""),
+			                    FALSE, 0, FALSE, 0, TRUE, 0, FALSE, 0));
+		}
+	}
+
+	/* get the ups battery runtime left if possible */
+	res=get_ups_variable ("battery.runtime", temp_buffer, sizeof (temp_buffer));
+	if (res == NOSUCHVAR) supported_options &= ~UPS_BATTLEFT;
+	else if ( res != OK)
+		return STATE_CRITICAL;
+	else {
+		supported_options |= UPS_BATTLEFT;
+		ups_battery_left = atof (temp_buffer) / 60;
+		xasprintf (&message, "%sLeft=%3.1fmin", message, ups_battery_left);
+
+		if (check_variable == UPS_BATTLEFT) {
+			if (check_crit==TRUE && ups_battery_left <= critical_value) {
+				result = STATE_CRITICAL;
+			}
+			else if (check_warn==TRUE && ups_battery_left<=warning_value) {
+				result = max_state (result, STATE_WARNING);
+			}
+			xasprintf (&data, "%s %s", data,
+			          fperfdata ("left", ups_battery_left, "",
+			                    check_warn, warning_value,
+			                    check_crit, critical_value,
+			                    TRUE, 0, FALSE, 0));
+		} else {
+			xasprintf (&data, "%s %s", data,
+			          fperfdata ("left", ups_battery_left, "",
 			                    FALSE, 0, FALSE, 0, TRUE, 0, FALSE, 0));
 		}
 	}
@@ -546,6 +577,8 @@ process_arguments (int argc, char **argv)
 				check_variable = UPS_UTILITY;
 			else if (!strcmp (optarg, "TEMP"))
 				check_variable = UPS_TEMP;
+			else if (!strcmp (optarg, "BATTLEFT"))
+				check_variable = UPS_BATTLEFT;
 			else if (!strcmp (optarg, "BATTPCT"))
 				check_variable = UPS_BATTPCT;
 			else if (!strcmp (optarg, "LOADPCT"))
@@ -623,7 +656,7 @@ print_help (void)
   printf (" %s\n", "-e, --extended-units");
   printf ("    %s\n", _("Allow nonstandard units in performance data (used for voltage and temperatures)"));
   printf (" %s\n", "-v, --variable=STRING");
-  printf ("    %s %s\n", _("Valid values for STRING are"), "LINE, TEMP, BATTPCT or LOADPCT");
+  printf ("    %s %s\n", _("Valid values for STRING are"), "LINE, TEMP, BATTLEFT, BATTPCT or LOADPCT");
 
 	printf (UT_WARN_CRIT);
 


### PR DESCRIPTION
`check_apcaccess` plugin for APC UPSes is able to report battery runtime left, e.g.:
`UPS OK - SMART-UPS 1000 Status=ONLINE Utility=223.6V Batt=100.0% Load=14.0% Temp=39.6°C Left=71.0min`

This adds similar functionality to the `check_ups` plugin. The runtime left is included in the status string:
`UPS OK - Status=Online Utility=236.1V Batt=100.0% Load=21.0% Temp=25.0C Left=74.0min`
as well as in the performance data.
