### PR TITLE
check_http: fix buffer size, it is insufficient size

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1419,7 +1419,7 @@ redir (char *pos, char *status_line)
   int i = 0;
   char *x;
   char xx[2];
-  char type[6];
+  char type[12];
   char *addr;
   char *url;
 


### PR DESCRIPTION
variable 'type' is set "https" or "server_type" in line 1493-1502.
But array size is 6 and it is insufficient. So fix it