### PR TITLE
check_ntp and friends: change calls to perfdata() to preserve complete threshold in output

### DIFF
--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -763,17 +763,17 @@ int process_arguments(int argc, char **argv){
 
 char *perfd_offset (double offset)
 {
-	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
+	return sperfdata ("offset", offset, "s",
+		offset_thresholds->warning_string,
+		offset_thresholds->critical_string,
 		FALSE, 0, FALSE, 0);
 }
 
 char *perfd_jitter (double jitter)
 {
-	return fperfdata ("jitter", jitter, "s",
-		do_jitter, jitter_thresholds->warning->end,
-		do_jitter, jitter_thresholds->critical->end,
+	return sperfdata ("jitter", jitter, "s",
+		jitter_thresholds->warning_string,
+		jitter_thresholds->critical_string,
 		TRUE, 0, FALSE, 0);
 }
 

--- a/plugins/check_ntp_peer.c
+++ b/plugins/check_ntp_peer.c
@@ -529,33 +529,33 @@ int process_arguments(int argc, char **argv){
 
 char *perfd_offset (double offset)
 {
-	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
+	return sperfdata ("offset", offset, "s",
+		offset_thresholds->warning_string,
+		offset_thresholds->critical_string,
 		FALSE, 0, FALSE, 0);
 }
 
 char *perfd_jitter (double jitter)
 {
-	return fperfdata ("jitter", jitter, "",
-		do_jitter, jitter_thresholds->warning->end,
-		do_jitter, jitter_thresholds->critical->end,
+	return sperfdata ("jitter", jitter, "",
+		jitter_thresholds->warning_string,
+		jitter_thresholds->critical_string,
 		TRUE, 0, FALSE, 0);
 }
 
 char *perfd_stratum (int stratum)
 {
-	return perfdata ("stratum", stratum, "",
-		do_stratum, (int)stratum_thresholds->warning->end,
-		do_stratum, (int)stratum_thresholds->critical->end,
+	return sperfdata_int ("stratum", stratum, "",
+		stratum_thresholds->warning_string,
+		stratum_thresholds->critical_string,
 		TRUE, 0, TRUE, 16);
 }
 
 char *perfd_truechimers (int num_truechimers)
 {
-	return perfdata ("truechimers", num_truechimers, "",
-		do_truechimers, (int)truechimer_thresholds->warning->end,
-		do_truechimers, (int)truechimer_thresholds->critical->end,
+	return sperfdata_int ("truechimers", num_truechimers, "",
+		truechimer_thresholds->warning_string,
+		truechimer_thresholds->critical_string,
 		TRUE, 0, FALSE, 0);
 }
 

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -564,9 +564,9 @@ int process_arguments(int argc, char **argv){
 
 char *perfd_offset (double offset)
 {
-	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
+	return sperfdata ("offset", offset, "s",
+		offset_thresholds->warning_string,
+		offset_thresholds->critical_string,
 		FALSE, 0, FALSE, 0);
 }
 


### PR DESCRIPTION
Resolves #435 