### PR TITLE
Correct thresholds output

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1522,10 +1522,10 @@ static void finish(int sig) {
         if (status == STATE_OK) {
           printf(" rta %0.3fms", host->rta / 1000);
         } else if (status == STATE_WARNING && host->rta_status == status) {
-          printf(" rta %0.3fms > %0.3fms", (float)host->rta / 1000,
+          printf(" rta %0.3fms >= %0.3fms", (float)host->rta / 1000,
                  (float)warn.rta / 1000);
         } else if (status == STATE_CRITICAL && host->rta_status == status) {
-          printf(" rta %0.3fms > %0.3fms", (float)host->rta / 1000,
+          printf(" rta %0.3fms >= %0.3fms", (float)host->rta / 1000,
                  (float)crit.rta / 1000);
         }
       }
@@ -1534,9 +1534,9 @@ static void finish(int sig) {
         if (status == STATE_OK) {
           printf(" lost %u%%", host->pl);
         } else if (status == STATE_WARNING && host->pl_status == status) {
-          printf(" lost %u%% > %u%%", host->pl, warn.pl);
+          printf(" lost %u%% >= %u%%", host->pl, warn.pl);
         } else if (status == STATE_CRITICAL && host->pl_status == status) {
-          printf(" lost %u%% > %u%%", host->pl, crit.pl);
+          printf(" lost %u%% >= %u%%", host->pl, crit.pl);
         }
       }
       /* jitter text output */
@@ -1544,9 +1544,9 @@ static void finish(int sig) {
         if (status == STATE_OK) {
           printf(" jitter %0.3fms", (float)host->jitter);
         } else if (status == STATE_WARNING && host->jitter_status == status) {
-          printf(" jitter %0.3fms > %0.3fms", (float)host->jitter, warn.jitter);
+          printf(" jitter %0.3fms >= %0.3fms", (float)host->jitter, warn.jitter);
         } else if (status == STATE_CRITICAL && host->jitter_status == status) {
-          printf(" jitter %0.3fms > %0.3fms", (float)host->jitter, crit.jitter);
+          printf(" jitter %0.3fms >= %0.3fms", (float)host->jitter, crit.jitter);
         }
       }
       /* mos text output */
@@ -1554,9 +1554,9 @@ static void finish(int sig) {
         if (status == STATE_OK) {
           printf(" MOS %0.1f", (float)host->mos);
         } else if (status == STATE_WARNING && host->mos_status == status) {
-          printf(" MOS %0.1f < %0.1f", (float)host->mos, (float)warn.mos);
+          printf(" MOS %0.1f <= %0.1f", (float)host->mos, (float)warn.mos);
         } else if (status == STATE_CRITICAL && host->mos_status == status) {
-          printf(" MOS %0.1f < %0.1f", (float)host->mos, (float)crit.mos);
+          printf(" MOS %0.1f <= %0.1f", (float)host->mos, (float)crit.mos);
         }
       }
       /* score text output */
@@ -1564,9 +1564,9 @@ static void finish(int sig) {
         if (status == STATE_OK) {
           printf(" Score %u", (int)host->score);
         } else if (status == STATE_WARNING && host->score_status == status) {
-          printf(" Score %u < %u", (int)host->score, (int)warn.score);
+          printf(" Score %u <= %u", (int)host->score, (int)warn.score);
         } else if (status == STATE_CRITICAL && host->score_status == status) {
-          printf(" Score %u < %u", (int)host->score, (int)crit.score);
+          printf(" Score %u <= %u", (int)host->score, (int)crit.score);
         }
       }
       /* order statis text output */


### PR DESCRIPTION
Hi,

This PR corrects thresholds output, to avoid such outputs :
`CRITICAL - hostname.com lost 50% > 50%`

We now have with this PR :
`CRITICAL - hostname.com lost 50% >= 50%`

Thank you !