### PR TITLE
Fix incorrect error message when nslookup returns an error status

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -276,19 +276,18 @@ main (int argc, char **argv)
         }
 
         int tmp = error_scan(chld_out.line[i]);
-        result = (result == STATE_UNKNOWN)
-            ? tmp
-            : (result < tmp)
-                ? tmp : result;
-        if (result != STATE_OK) {
-            msg = strchr (chld_out.line[i], ':');
-            if(msg) {
-                msg++;
+        if (result == STATE_UNKNOWN || result < tmp) {
+            result = tmp;
+            if (result != STATE_OK) {
+                msg = strchr (chld_out.line[i], ':');
+                if (msg) {
+                    msg++;
+                }
+                else {
+                    msg = chld_out.line[i];
+                }
+                break;
             }
-            else {
-                msg = chld_out.line[i];
-            }
-            break;
         }
     }  /*This is the end of the scan stdout loop */
 


### PR DESCRIPTION
Logic is incorrect when processing an error code returned by nslookup. The following code bails out early _and_ overwrites the error message for errors such as an invalid domain:

```
        int tmp = error_scan(chld_out.line[i]);
        result = (result == STATE_UNKNOWN)
            ? tmp
            : (result < tmp)
                ? tmp : result;
        if (result != STATE_OK) {
            msg = strchr (chld_out.line[i], ':');
            if(msg) {
                msg++;
            }
            else {
                msg = chld_out.line[i];
            }
            break;
        }
```

Examples:
```
~/tmp/nagios-plugins-2.0.3/plugins$ ./check_dns -H no-such-domain.com
Domain no-such-domain.com was not found by the server

~/tmp/nagios-plugins-2.2.1/plugins$ ./check_dns -H no-such-domain.com
DNS WARNING -           192.168.1.1

# After applying this patch
~/tmp/nagios-plugins/plugins$ ./check_dns -H no-such-domain.com
Domain no-such-domain.com was not found by the server
```