### PR TITLE
Fix inconsistent timeout behaviour of check_ping plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1119,10 +1119,10 @@ then
 	ac_cv_ping_packets_first=yes
 	AC_MSG_RESULT([$with_ping_command])
 
-elif $PATH_TO_PING -n -U -W 10 -c 1 127.0.0.1 2>/dev/null | \
+elif $PATH_TO_PING -n -U -w 10 -c 1 127.0.0.1 2>/dev/null | \
 	egrep -i "^round-trip|^rtt" >/dev/null
 then
-	with_ping_command="$PATH_TO_PING -n -U -W %d -c %d %s"
+	with_ping_command="$PATH_TO_PING -n -U -w %d -c %d %s"
 	ac_cv_ping_packets_first=yes
 	ac_cv_ping_has_timeout=yes
 	AC_MSG_RESULT([$with_ping_command])
@@ -1243,10 +1243,10 @@ elif test "x$PATH_TO_PING6" != "x"; then
 		ac_cv_ping6_packets_first=yes
 		AC_MSG_RESULT([$with_ping6_command])
 
-	elif $PATH_TO_PING6 -n -U -W 10 -c 1 ::1 2>/dev/null | \
+	elif $PATH_TO_PING6 -n -U -w 10 -c 1 ::1 2>/dev/null | \
 		egrep -i "^round-trip|^rtt" >/dev/null
 	then
-		with_ping6_command="$PATH_TO_PING6 -n -U -W %d -c %d %s"
+		with_ping6_command="$PATH_TO_PING6 -n -U -w %d -c %d %s"
 		ac_cv_ping6_packets_first=yes
 		ac_cv_ping_has_timeout=yes
 		AC_MSG_RESULT([$with_ping6_command])


### PR DESCRIPTION
Revert commit b7ee01a257d0bee30b3ef4d579ad56533f389e70 (Fix for issue #139) which incorrectly modifies timeout behaviour of the `check_ping` plugin.

See also:
https://github.com/nagios-plugins/nagios-plugins/issues/419
https://github.com/nagios-plugins/nagios-plugins/issues/323
https://github.com/nagios-plugins/nagios-plugins/issues/139

The above commit modified the `/bin/ping` command line to use the `-W` parameter instead of `-w` for specifying the timeout. `-w` is a global timeout for the command whereas `-W` specifies the maximum time to wait for a single ping response. This caused a number of issues:

1. For unresponsive hosts instead of the ping command timing out and providing useful output, viz:
`PING CRITICAL - Packet loss = 100%|rta=1200.000000ms;600.000000`
we get instead:
`CRITICAL - Plugin timed out`
This is because the `-W` param is effectively a timeout for the _last_ ping packet sent, so the ping command is executing for a max "timeout + num packets" seconds instead of "timeout" seconds. Thus the SIGALRM set to "timeout + 1" seconds is triggering and killing the plugin.

2. The above behaviour is inconsistent with other ping commands specified in `configure.ac` for other OS's such as BSD Unix. Eg: `-X` for `/bin/ping6` or `-t` for  `/bin/ping`, which both specify a global timeout like `-w` on GNU/Linux.

3. To properly address Issue #139 I believe we'll need to add an additional parameter to `check_ping` to specify the maximum wait time for a single ping packet.