### PR TITLE
check_dns: Improved error messaging for "connection timed out" and "connection refused" cases.

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -423,13 +423,15 @@ main (int argc, char **argv)
 int
 error_scan (char *input_buffer)
 {
-
-    /* the DNS lookup timed out */
     if (strstr (input_buffer, _("Note: nslookup is deprecated and may be removed from future releases.")) ||
         strstr (input_buffer, _("Consider using the `dig' or `host' programs instead.  Run nslookup with")) ||
         strstr (input_buffer, _("the `-sil[ent]' option to prevent this message from appearing.")))
     {
         return STATE_OK;
+    }
+    /* the DNS lookup timed out */
+    else if (strcasestr (input_buffer, "connection timed out")) {
+        die (STATE_CRITICAL, "%s %s %s\n", _("Connection to DNS"), (strlen(dns_server)==0)?tmp_dns_server:dns_server, _("timed out"));
     }
     /* DNS server is not running... */
     else if (strstr (input_buffer, "No response from server")) {
@@ -440,7 +442,7 @@ error_scan (char *input_buffer)
         die (STATE_CRITICAL, "%s %s %s\n", _("DNS"), (strlen(dns_server)==0)?tmp_dns_server:dns_server, _("has no records"));
     }
     /* Connection was refused */
-    else if (strstr (input_buffer, "Connection refused") ||
+    else if (strcasestr (input_buffer, "Connection refused") ||
              strstr (input_buffer, "Couldn't find server") ||
              strstr (input_buffer, "Refused") ||
              (strstr (input_buffer, "** server can't find") &&


### PR DESCRIPTION
Currently `check_dns` returns somewhat unhelpful error messages for some Connection timed out and Connection refused errors returned by nslookup. 

Examples on Ubuntu 18.04:

```
$ nslookup foo.com 1.2.3.4
;; connection timed out; no servers could be reached

# Before this PR
$ ./check_dns -H foo.com -s 1.2.3.4
DNS WARNING - nslookup returned an error status

# After this PR
$ ./check_dns -H foo.com -s 1.2.3.4
Connection to DNS 1.2.3.4 timed out
```

```
$ nslookup -type=ANY foo.com ns1.dynadot.com
;; Connection to 35.160.240.86#53(35.160.240.86) for foo.com failed: connection refused.
;; Connection to 54.69.45.191#53(54.69.45.191) for foo.com failed: connection refused.
;; Connection to 52.25.56.204#53(52.25.56.204) for foo.com failed: connection refused.
;; Connection to 54.68.4.223#53(54.68.4.223) for foo.com failed: connection refused.

# Before this PR
$ ./check_dns -H foo.com -s ns1.dynadot.com -q ANY
DNS WARNING - nslookup returned an error status

# After this PR
$ ./check_dns -H foo.com -s ns1.dynadot.com -q ANY
Connection to DNS ns1.dynadot.com was refused
```