### PR TITLE
Fix inconsistent timeout behaviour of check_ping plugin: Alternative 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1134,10 +1134,10 @@ then
 	ac_cv_ping_packets_first=yes
 	AC_MSG_RESULT([$with_ping_command])
 
-elif $PATH_TO_PING -n -t 10 -c 1 127.0.0.1 2>/dev/null | \
+elif $PATH_TO_PING -n -W 10000 -c 1 127.0.0.1 2>/dev/null | \
   egrep -i "^round-trip|^rtt" >/dev/null
 then
-  with_ping_command="$PATH_TO_PING -n -t %d -c %d %s"
+  with_ping_command="$PATH_TO_PING -n -W %d000 -c %d %s"
   ac_cv_ping_packets_first=yes
   ac_cv_ping_has_timeout=yes
   AC_MSG_RESULT([$with_ping_command])
@@ -1258,10 +1258,10 @@ elif test "x$PATH_TO_PING6" != "x"; then
 		ac_cv_ping6_packets_first=yes
 		AC_MSG_RESULT([$with_ping6_command])
 
-  elif $PATH_TO_PING6 -n -X 10 -c 1 ::1 2>/dev/null | \
+  elif $PATH_TO_PING6 -n -x 10000 -c 1 ::1 2>/dev/null | \
     egrep -i "^round-trip|^rtt" >/dev/null
   then
-    with_ping6_command="$PATH_TO_PING6 -n -X %d -c %d %s"
+    with_ping6_command="$PATH_TO_PING6 -n -x %d000 -c %d %s"
     ac_cv_ping6_packets_first=yes
     ac_cv_ping_has_timeout=yes
     AC_MSG_RESULT([$with_ping6_command])

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -124,7 +124,11 @@ main (int argc, char **argv)
 		/* does the host address of number of packets argument come first? */
 #ifdef PING_PACKETS_FIRST
 # ifdef PING_HAS_TIMEOUT
-		xasprintf (&cmd, rawcmd, timeout_interval, max_packets, addresses[i]);
+        // ping's -W timeout argument is the timeout for the _last_ packet sent.
+        // Packets are sent every second, so we deduct the number of packets from
+        // the timeout set in the command.
+        unsigned int ping_timeout = timeout_interval > max_packets ? timeout_interval - max_packets : 1;
+		xasprintf (&cmd, rawcmd, ping_timeout, max_packets, addresses[i]);
 # else
 		xasprintf (&cmd, rawcmd, max_packets, addresses[i]);
 # endif

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -124,10 +124,10 @@ main (int argc, char **argv)
 		/* does the host address of number of packets argument come first? */
 #ifdef PING_PACKETS_FIRST
 # ifdef PING_HAS_TIMEOUT
-        // ping's -W timeout argument is the timeout for the _last_ packet sent.
-        // Packets are sent every second, so we deduct the number of packets from
-        // the timeout set in the command.
-        unsigned int ping_timeout = timeout_interval > max_packets ? timeout_interval - max_packets : 1;
+		// ping's -W timeout argument is the timeout for the _last_ packet sent.
+		// Packets are sent every second, so we deduct the number of packets from
+		// the timeout set in the command.
+		unsigned int ping_timeout = timeout_interval > max_packets ? timeout_interval - max_packets : 1;
 		xasprintf (&cmd, rawcmd, ping_timeout, max_packets, addresses[i]);
 # else
 		xasprintf (&cmd, rawcmd, max_packets, addresses[i]);


### PR DESCRIPTION
This PR is an alternative to https://github.com/nagios-plugins/nagios-plugins/pull/502 and attempts to resolve the same issue, while ensuring `check_ping` does not send more than `-c max_packets` packets for dead hosts.

For unresponsive hosts instead of the ping command timing out and providing useful output, viz:
`PING CRITICAL - Packet loss = 100%|rta=1200.000000ms;600.000000`
we get instead:
`CRITICAL - Plugin timed out`

The PR essentially includes 2 separate fixes:

1. The timeout parameters for `ping` (`-t`) and `ping6` (`-X`) used on **FreeBSD** are not compatible with the timeout parameter now used in linux (`-W`). The former are global timeouts whereas the latter is the maximum wait time for the _last packet sent_. So, the former were converted to `-W` and `-x` respectively per these docs:
    - https://www.freebsd.org/cgi/man.cgi?query=ping&apropos=0&sektion=8&manpath=FreeBSD+10.2-RELEASE&arch=default&format=html
    - https://www.freebsd.org/cgi/man.cgi?query=ping6&apropos=0&sektion=8&manpath=FreeBSD+10.2-RELEASE&arch=default&format=html

2. Since the the linux "deadline" parameter (`-w`) was changed to the "timeout" (`-W`) (see https://github.com/nagios-plugins/nagios-plugins/issues/139), the ping commands execute for longer than the SIGALRM defined for the plugin. This is because the `-W` param is effectively a timeout for the last ping packet sent, so the ping command is executing for a max "timeout + num packets" seconds instead of "timeout" seconds. Thus the SIGALRM set to "timeout + 1" seconds is triggering and killing the plugin.

    The proposed fix is to set the timeout passed to the `ping` command to: 
    `MAX(1, timeout - num_packets)`

Tested on Ubuntu 18.04 and FreeBSD 11.3.