### PR TITLE
Remove redundant debug print from check_ping

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -139,7 +139,6 @@ main (int argc, char **argv)
 		this_result = run_ping (cmd, addresses[i]);
 
 		if (pl == UNKNOWN_PACKET_LOSS || rta < 0.0) {
-			printf ("%s\n", cmd);
 			die (STATE_UNKNOWN,
 			           _("CRITICAL - Could not interpret output from ping command\n"));
 		}


### PR DESCRIPTION
Due to an extra `printf()` the output from the plugin is incorrect when ping output cannot be parsed:

Before fix:
```
$ check_ping -w '600.0,30%' -c '1200.0,60%' -p 5 -t 20 -H somedomain.com
/bin/ping -n -U -W 15 -c 5 somedomain.com
CRITICAL - Could not interpret output from ping command
```

After fix:
```
$ check_ping -w '600.0,30%' -c '1200.0,60%' -p 5 -t 20 -H somedomain.com
CRITICAL - Could not interpret output from ping command
```
