### PR TITLE
Fix typo in check for required perl modules for check_ssl_validity

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1502,7 +1502,7 @@ else
 	AC_MSG_WARN([Tried $PERL - install Net::SNMP perl module if you want to use the perl snmp plugins])
 fi
 
-if ( $PERL -M"Crypt::X509" -M"Date::Parse" -M"LWP::Simple" -M "Text::Glob" -e 'exit' 2>/dev/null )
+if ( $PERL -M"Crypt::X509" -M"Date::Parse" -M"LWP::Simple" -M"Text::Glob" -e 'exit' 2>/dev/null )
 then
   AC_MSG_CHECKING(for Crypt::X509, Date::Parse, LWP::Simple, Text::Glob perl modules)
   AC_MSG_RESULT([found])


### PR DESCRIPTION
Hello,

I'm no perl expert, but the check always fails on my Ubuntu 18.04 installation. With the whitespace removed it works and looking at the other parameters it seems to be correct.

Regards,
Ben