### PR TITLE
Correct closing parenthesis placement.

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1220,7 +1220,7 @@ check_http (void)
         seen_length = pagesize - content_start;
         /* Continue receiving the body until content-length is met */
         while (seen_length < content_length
-            && (i = my_recv(buffer, MAX_INPUT_BUFFER-1) > 0)) {
+            && (i = my_recv(buffer, MAX_INPUT_BUFFER-1)) > 0) {
 
             buffer[i] = '\0';
 


### PR DESCRIPTION
Without this, page content reads would be truncated prematurely since i
would be set to 1 (meaning TRUE) and not the actual length of bytes
read.  Any page that was less than the max buffer length (8192 bytes)
would only have its first byte read.