### PR TITLE
Add -d switch to check_ifstatus.pl

### DIFF
--- a/plugins-scripts/check_ifstatus.pl
+++ b/plugins-scripts/check_ifstatus.pl
@@ -10,6 +10,7 @@
 #  Added -M option (10/2003)
 #  Added SNMPv3 support (10/2003)
 #  Added -n option (07/2014)
+#  Added -d option (04/2020)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -98,12 +99,12 @@ my $opt_V ;
 my $opt_u;
 my $opt_n;
 my $opt_x ;
+my $opt_d;
 my %excluded ;
 my %unused_names ;
 my @unused_ports ;
 my %session_opts;
-
-
+my @exclude_descriptions;
 
 
 
@@ -135,6 +136,7 @@ if (!defined($session)) {
 }
 
 
+push(@snmpoids,$snmpLocIfDescr);
 push(@snmpoids,$snmpIfOperStatus);
 push(@snmpoids,$snmpIfAdminStatus);
 push(@snmpoids,$snmpIfDescr);
@@ -179,29 +181,38 @@ foreach $key (keys %ifStatus) {
 	if (!defined($ifStatus{$key}{'notInUse'}) && !grep(/^${ifName}/, @unused_ports )) {
 		# check only if interface is administratively up
 		if ($ifStatus{$key}{$snmpIfAdminStatus} == 1 ) {
-			#check only if interface is not excluded
+			#check only if interface is not excluded (by name)
 			if (!defined $unused_names{$ifStatus{$key}{$snmpIfDescr}} ) {
-				# check only if interface type is not listed in %excluded
-				if (!defined $excluded{$ifStatus{$key}{$snmpIfType}} ) {
-					if ($ifStatus{$key}{$snmpIfOperStatus} == 1 ) { $ifup++ ; }
-					if ($ifStatus{$key}{$snmpIfOperStatus} == 2 ) {
-									$ifdown++ ;
-									if (defined $ifXTable) {
-										$ifmessage .= sprintf("%s: down -> %s<BR>\n", $ifStatus{$key}{$snmpIfName}, $ifStatus{$key}{$snmpIfAlias});
-									}else{
-										$ifmessage .= sprintf("%s: down <BR>\n",$ifStatus{$key}{$snmpIfDescr});
-									}
+				#check only if interface is not excluded (by description)
+				#counter for matching descriptions
+				my $match_descr = 0;
+				foreach my $description (@exclude_descriptions) {
+					if ($ifStatus{$key}{$snmpLocIfDescr} =~ /^$description/) { $match_descr = 1; }
+				}
+				if ($match_descr == 0) {
+					# check only if interface type is not listed in %excluded
+					if (!defined $excluded{$ifStatus{$key}{$snmpIfType}} ) {
+						if ($ifStatus{$key}{$snmpIfOperStatus} == 1 ) { $ifup++ ; }
+						if ($ifStatus{$key}{$snmpIfOperStatus} == 2 ) {
+										$ifdown++ ;
+										if (defined $ifXTable) {
+											$ifmessage .= sprintf("%s: down -> %s<BR>\n", $ifStatus{$key}{$snmpIfName}, $ifStatus{$key}{$snmpIfAlias});
+										}else{
+											$ifmessage .= sprintf("%s: down <BR>\n",$ifStatus{$key}{$snmpIfDescr});
+										}
+						}
+						if ($ifStatus{$key}{$snmpIfOperStatus} == 5 ) { $ifdormant++ ;}
+					} else {
+						$ifexclude++;
 					}
-					if ($ifStatus{$key}{$snmpIfOperStatus} == 5 ) { $ifdormant++ ;}
 				} else {
 					$ifexclude++;
 				}
 			} else {
 				$ifunused++;
 			}
-		
 		}
-	}else{
+	} else {
 		$ifunused++;
 	}
 }
@@ -265,6 +276,9 @@ sub print_help() {
 	printf "                     the descriptive name.  Do not use if you don't know what this is. \n";
 	printf "   -x (--exclude)    A comma separated list of ifType values that should be excluded \n";
 	printf "                     from the report (default for an empty list is PPP(23).\n";
+	printf "   -d (--exclude_ports_by_description) A comma separated list of LocIfDescr values that should be excluded \n";
+	printf "                     from the report (default is an empty exclusion list). Done using regexp '/^arg/', ex:\n";
+	printf "                     '-d connect,test' will match with descriptions like 'testing phase' but not 'in testing'.\n";
 	printf "   -n (--unused_ports_by_name) A comma separated list of ifDescr values that should be excluded \n";
 	printf "                     from the report (default is an empty exclusion list).\n";
 	printf "   -u (--unused_ports) A comma separated list of ifIndex values that should be excluded \n";
@@ -294,22 +308,23 @@ sub process_arguments() {
 		"V"   => \$opt_V, "version"    => \$opt_V,
 		"h"   => \$opt_h, "help"       => \$opt_h,
 		"v=s" => \$snmp_version, "snmp_version=s"  => \$snmp_version,
-		"C=s" => \$community,"community=s" => \$community,
+		"C=s" => \$community, "community=s" => \$community,
+		"d=s" => \$opt_d, "exclude_ports_by_description=s" => \$opt_d,
 		"L=s" => \$seclevel, "seclevel=s" => \$seclevel,
 		"a=s" => \$authproto, "authproto=s" => \$authproto,
-		"U=s" => \$secname,   "secname=s"   => \$secname,
-		"A=s" => \$authpass,  "authpass=s"  => \$authpass,
-		"X=s" => \$privpass,  "privpass=s"  => \$privpass,
-		"P=s" => \$privproto,  "privproto=s"  => \$privproto,
-		"c=s" => \$context,   "context=s"   => \$context,
-		"p=i" =>\$port, "port=i" => \$port,
+		"U=s" => \$secname, "secname=s"   => \$secname,
+		"A=s" => \$authpass, "authpass=s"  => \$authpass,
+		"X=s" => \$privpass, "privpass=s"  => \$privpass,
+		"P=s" => \$privproto, "privproto=s"  => \$privproto,
+		"c=s" => \$context, "context=s"   => \$context,
+		"p=i" => \$port, "port=i" => \$port,
 		"H=s" => \$hostname, "hostname=s" => \$hostname,
-		"I"		=> \$ifXTable, "ifmib" => \$ifXTable,
-		"x:s"		=>	\$opt_x,   "exclude:s" => \$opt_x,
-		"u=s" => \$opt_u,  "unused_ports=s" => \$opt_u,
+		"I"   => \$ifXTable, "ifmib" => \$ifXTable,
+		"x:s" => \$opt_x, "exclude:s" => \$opt_x,
+		"u=s" => \$opt_u, "unused_ports=s" => \$opt_u,
 		"n=s" => \$opt_n, "unused_ports_by_name=s" => \$opt_n,
 		"M=i" => \$maxmsgsize, "maxmsgsize=i" => \$maxmsgsize,
-		"t=i" => \$timeout,    "timeout=i" => \$timeout,
+		"t=i" => \$timeout, "timeout=i" => \$timeout,
 		);
 		
 	if ($status == 0){
@@ -414,7 +429,13 @@ sub process_arguments() {
 			$excluded{23} = 1; # default PPP(23) if empty list - note (AIX seems to think PPP is 22 according to a post)
 		}
 	}
+
+	# Exclude interfaces by descriptions
+	if (defined $opt_d) {
+		@exclude_descriptions = split(/,/,$opt_d);
+	}
 	
+
 	# Excluded interface descriptors
 	if (defined $opt_n) {
 		my @unused = split(/,/,$opt_n);


### PR DESCRIPTION
Hello,

My colleague Eloi did add a -d switch to check_ifstatus.pl in order to be able to exclude interfaces on a per description basis. This allows to exclude interfaces that have a pattern such as "phone" in their descriptions.

Could you check this PR?

Thanks.

Best regards,