### PR TITLE
declare 'procjid' to prevent compilation error

### DIFF
--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -349,6 +349,7 @@ int cmpstringp(const void *p1, const void *p2) {
 	pid_t procpid = 0;
 	pid_t procppid = 0;
 	pid_t kthread_ppid = 0;
+	int procjid = 0;
 	int procvsz = 0;
 	int procrss = 0;
 	float procpcpu = 0;


### PR DESCRIPTION
In file included from common.h:34,
                 from check_load.c:35:
check_load.c: In function 'cmpstringp':
../config.h:2002:58: error: 'procjid' undeclared (first use in this function); did you mean 'procpid'?
 2002 | #define PS_VARLIST procstat,&procuid,&procpid,&procppid,&procjid,&procvsz,&procrss,&procpcpu,procprog,&pos