### PR TITLE
Update check_http client certificate to use chain file

### DIFF
--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -161,7 +161,7 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 		return STATE_CRITICAL;
 	}
 	if (cert && privkey) {
-		SSL_CTX_use_certificate_file(c, cert, SSL_FILETYPE_PEM);
+		SSL_CTX_use_certificate_chain_file(c, cert);
 		SSL_CTX_use_PrivateKey_file(c, privkey, SSL_FILETYPE_PEM);
 #ifdef USE_OPENSSL
 		if (!SSL_CTX_check_private_key(c)) {


### PR DESCRIPTION
I was unable to monitor an internal company web site that required a client certificate using check_http.  The full signing chain was not being sent to the server, so the certificate was being rejected.  Modifying the load of client certificate to use SSL_CTX_use_certificate_chain_file instead of SSL_CTX_use_certificate_file and updating the file to include the cert chain resolved the issue.

Also, openssl documentation notes that use of this function should now be preferred.