### PR TITLE
use a temp file for log diffing

### DIFF
--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -188,6 +188,20 @@ elif [ ! -r "$logfile" ] ; then
     exit "$STATE_UNKNOWN"
 fi
 
+# Copy the logfile to a temporary file, to prevent diff from 
+# never finishing when $logfile continues to be written to
+# during the diff
+
+templog="/tmp/temp_check_log.tmp"
+if [ -x /bin/mktemp ]; then
+    templog=$(/bin/mktemp /tmp/temp_check_log.XXXXXXXXXX)
+else
+    templogdate=$(/bin/date '+%H%M%S')
+    templog="/tmp/temp_check_log.${templogdate}"
+fi
+cp "$logfile" "$templog"
+logfile="$templog"
+
 # If the old log file doesn't exist, this must be the first time
 # we're running this test, so copy the original log file over to
 # the old diff file and exit
@@ -225,6 +239,7 @@ lastentry=$(egrep "$query" "$tempdiff" | tail -1)
 
 rm -f "$tempdiff"
 cat "$logfile" > "$oldlog"
+rm -f "$templog"
 
 if [ "$count" = "0" ]; then # no matches, exit with no error
     echo "Log check ok - 0 pattern matches found|match=$count;;;0"


### PR DESCRIPTION
On recent RHEL7 variants with multi-mb logs that continue to be written to, the diff command never exits and uses 100% CPU causing this log check to fail.
Copying the logfile to a temporary file (using the same logic used later in the script) seems to solve this issue for the most part. I believe this would resolve the issues, and not create any extra issues.
