### PR TITLE
check_disk - fix false DISK CRITICAL alert for btrfs filesystems due to BSD Gnulib workaround

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -1310,10 +1310,14 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
 
 void
 get_path_stats (struct parameter_list *p, struct fs_usage *fsp) {
+#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(OpenBSD )
   /* 2007-12-08 - Workaround for Gnulib reporting insanely high available
   * space on BSD (the actual value should be negative but fsp->fsu_bavail
   * is unsigned) */
   p->available = fsp->fsu_bavail > fsp->fsu_bfree ? 0 : fsp->fsu_bavail;
+#else
+  p->available = fsp->fsu_bavail;
+#endif
   p->available_to_root = fsp->fsu_bfree;
   p->used = fsp->fsu_blocks - fsp->fsu_bfree;
   if (freespace_ignore_reserved) {


### PR DESCRIPTION
Fixes  false DISK CRITICAL alert for btrfs filesystems, as described here: https://github.com/nagios-plugins/nagios-plugins/issues/568