### PR TITLE
check_ntp.pl: add support for ntpsec ntpdate

### DIFF
--- a/plugins-scripts/check_ntp.pl
+++ b/plugins-scripts/check_ntp.pl
@@ -230,6 +230,14 @@ while (<NTPDATE>) {
 	
 	}
 
+	# Parse output from ntpsec's ntpdate
+	if (/ ([+-.\d]+) \+\/-.* s(\d+) (no|add|del)-leap/) {
+		$offset = $1;
+		$stratum = $2;
+		$ntpdate_error = $ERRORS{"OK"};
+		print "ntperr = $ntpdate_error \n" if $verbose;
+	}
+
 	if (/no server suitable for synchronization found/) {
 		if ($stratum == 16) {
 			$ntpdate_error = $ERRORS{"WARNING"};


### PR DESCRIPTION
ntpsec is a fork of ntp. It provides an ntpdate wrapper for compatibility, but it has a different output, which is not parsed by the check_ntp.pl plugin. This PR tries to fix that.