### PR TITLE
patch #588

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -149,6 +149,7 @@ void print_help (void);
 void print_usage (void);
 
 extern int check_hostname;
+extern int allow_tls_shutdown;
 
 
 int
@@ -225,7 +226,8 @@ process_arguments (int argc, char **argv)
         INVERT_REGEX = CHAR_MAX + 1,
         SNI_OPTION,
         VERIFY_HOST,
-        CONTINUE_AFTER_CHECK_CERT
+        CONTINUE_AFTER_CHECK_CERT,
+        ALLOW_TLS_SHUTDOWN
     };
 
     int option = 0;
@@ -267,6 +269,7 @@ process_arguments (int argc, char **argv)
         {"use-ipv6", no_argument, 0, '6'},
         {"extended-perfdata", no_argument, 0, 'E'},
         {"show-url", no_argument, 0, 'U'},
+        {"allow-tls-shutdown", no_argument, 0, ALLOW_TLS_SHUTDOWN},
         {0, 0, 0, 0}
     };
 
@@ -404,6 +407,9 @@ enable_ssl:
             break;
         case VERIFY_HOST:
             check_hostname = 1;
+            break;
+        case ALLOW_TLS_SHUTDOWN:
+            allow_tls_shutdown = 1;
             break;
         case 'f': /* onredirect */
             if (!strcmp (optarg, "stickyport"))
@@ -1818,6 +1824,8 @@ print_help (void)
     printf (" %s\n", "-K, --private-key=FILE");
     printf ("   %s\n", _("Name of file containing the private key (PEM format)"));
     printf ("   %s\n", _("matching the client certificate"));
+    printf (" %s\n", "--allow-tls-shutdown");
+    printf ("    %s\n", _("Allow shut down of TLS/SSL. Controlled and by the specifications of the TLS/SSL protocol."));
 #endif
 
     printf (" %s\n", "-e, --expect=STRING");

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -31,6 +31,7 @@
 #include "netutils.h"
 
 int check_hostname = 0;
+int allow_tls_shutdown = 0;
 #ifdef HAVE_SSL
 static SSL_CTX *c=NULL;
 static SSL *s=NULL;
@@ -184,7 +185,8 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 			SSL_set_tlsext_host_name(s, host_name);
 #endif
 		SSL_set_fd(s, sd);
-		if (SSL_connect(s) == 1) {
+		int ssl_connect_return = SSL_connect(s);
+		if ( ssl_connect_return == 1 || ( allow_tls_shutdown && ssl_connect_return == 0 ) ) {
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
 			if (check_hostname && host_name && *host_name) {
 				X509 *certificate=SSL_get_peer_certificate(s);


### PR DESCRIPTION
With that patch the problem can be resolved via an additional option


https://github.com/nagios-plugins/nagios-plugins/issues/588


```
plugins/check_http' '--sni' '-C' '93' '-H' 'secure-mtls-endpoint.example.com' '-I' 'secure-mtls-endpoint.example.com' '-S1.2+' --allow-tls-shutdown
SSL OK - Certificate '*.example.com' will expire in 304 days on 2021-12-20 00:59 +0100/CET.
```