### PR TITLE
Added the functionality to compare the returned addresses/records individually

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -675,8 +675,7 @@ print_help (void)
     printf ("%s\n", " -a, --expected-address=IP-ADDRESS|HOST");
     printf ("    %s\n", _("Optional IP-ADDRESS you expect the DNS server to return. HOST must end with"));
     printf ("    %s\n", _("a dot (.). This option can be repeated multiple times (Returns OK if any"));
-    printf ("    %s\n", _("value match). If multiple addresses are returned at once, you have to match"));
-    printf ("    %s\n", _("the whole string of addresses separated with commas (sorted alphabetically)."));
+    printf ("    %s\n", _("value match)."));
     printf ("    %s\n", _("If you would like to test for the presence of a cname, combine with -n param."));
     printf ("%s\n", " -A, --expect-authority");
     printf ("    %s\n", _("Optionally expect the DNS server to be authoritative for the lookup"));

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -119,6 +119,7 @@ main (int argc, char **argv)
     int parse_address = FALSE; /* This flag scans for Address: but only after Name: */
     output chld_out, chld_err;
     size_t i;
+    size_t j;
 
     setlocale (LC_ALL, "");
     bindtextdomain (PACKAGE, LOCALEDIR);
@@ -334,9 +335,12 @@ main (int argc, char **argv)
         result = STATE_CRITICAL;
         temp_buffer = "";
         for (i=0; i<expected_address_cnt; i++) {
-            /* check if we get a match and prepare an error string */
-            if (strcasecmp(address, expected_address[i]) == 0) result = STATE_OK;
-            xasprintf(&temp_buffer, "%s%s; ", temp_buffer, expected_address[i]);
+            /* loop through each returned address/record to compare individually */
+            for(j=0; j < n_addresses; j++) {
+                /* check if we get a match and prepare an error string */
+                if (strcasecmp(addresses[j], expected_address[i]) == 0) result = STATE_OK;
+                xasprintf(&temp_buffer, "%s%s; ", temp_buffer, expected_address[i]);
+            }
         }
         if (result == STATE_CRITICAL) {
             /* Strip off last semicolon... */


### PR DESCRIPTION
Currently if there are multiple records/addresses returned by the check you need to know them all in order to get the check to work.

This fails:

```
[root@xid ~]# /usr/local/nagios/libexec/check_dns -H 192.168.232.213 -a 'c77.contoso.local.' -q any
DNS CRITICAL - expected 'c77.contoso.local.' but got 'c77-extra.contoso.local.,c77.contoso.local.'
```

You would need to know them all to get it to work:

```
[root@xid ~]# /usr/local/nagios/libexec/check_dns -H 192.168.232.213 -a 'c77-extra.contoso.local.,c77.contoso.local.' -q any
DNS OK: 0.008 seconds response time. 192.168.232.213 returns c77-extra.contoso.local.,c77.contoso.local.|time=0.007506s;;;0.000000
```

The added feature compares all returned records and compares them so it matches any of them:

```
[root@xid ~]# ./plugins/check_dns -H 192.168.232.213 -a 'c77-extra.contoso.local.' -q any
DNS OK: 0.007 seconds response time. 192.168.232.213 returns c77-extra.contoso.local.,c77.contoso.local.|time=0.006563s;;;0.000000

[root@xid ~]# ./plugins/check_dns -H 192.168.232.213 -a 'c77.contoso.local.' -q any
DNS OK: 0.009 seconds response time. 192.168.232.213 returns c77-extra.contoso.local.,c77.contoso.local.|time=0.009289s;;;0.000000
```