### PR TITLE
Skip non-http CRL DPs in check_ssl_validity.pl

### DIFF
--- a/plugins-scripts/check_ssl_validity.pl
+++ b/plugins-scripts/check_ssl_validity.pl
@@ -338,6 +338,11 @@ else {
     @crldps = @{$decoded->CRLDistributionPoints};
     $crlskip = 0;
     foreach $crldp (@crldps) {
+        if ($crldp !~ "^http://") {
+            if ($opt_d) { print "Skipping non-http CRL DP $crldp\n" }
+            next;
+        }
+
         if ($opt_d) {
             print "Checking CRL DP $crldp.\n";
         }


### PR DESCRIPTION
The check CRL DP routine can only (attempt) to download http:// CRLs, but fails on non-http CRL DPs like ldap://

Unfortunately this breaks the whole validation process, even if a valid CRL could be downloaded already via http:// and the ldap:// DP is second in line.
This issue should be addressed seperately. I.e. exit the whole loop after a valid CRL was found.