### PR TITLE
modify check_log.sh with line breaks so manpage looks nice

### DIFF
--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -73,7 +73,10 @@ print_usage() {
     echo "Usage: $PROGNAME --help"
     echo "Usage: $PROGNAME --version"
     echo "     Additional parameter:"
-    echo "        -w (--max_warning) If used, determines the maximum matching value to return as warning, when finding more matching lines than this parameter will return as critical. If not used, will consider as default 0 (any matching will consider as critical)"
+    echo "        -w (--max_warning) If used, determines the maximum matching value to return"
+    echo "         as warning, when finding more matching lines than this parameter will"
+    echo "         return as critical. If not used, will consider as default 0 (any matching"
+    echo "         will consider as critical)"
     echo "Usage: $PROGNAME -F logfile -O oldlog -q query -w <number>"
 }
 


### PR DESCRIPTION
Current manpage for check_log clips the usage info off. I've added linebreaks around col 95 to be more consistent with other script plugins, and to fix the manpage looking weird.

https://nagios-plugins.org/doc/man/check_log.html