### PR TITLE
check_icmp: replace 0 with U in performance output.

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1644,7 +1644,7 @@ static void finish(int sig) {
     if (jitter_mode) {
       if (!host->jitter || !host->jitter_max || !host->jitter_min) {
         printf("%s%sjitter_avg=Ums;%0.3f;%0.3f;0; %s%sjitter_max=Ums "
-             "%s%sjitter_min=U ",
+             "%s%sjitter_min=Ums ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)warn.jitter, (float)crit.jitter,

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1607,7 +1607,7 @@ static void finish(int sig) {
     }
     if (rta_mode) {
       if (!host->rta) {
-        printf("%s%srta=U;%0.3f;%0.3f;0; ",
+        printf("%s%srta=Ums;%0.3f;%0.3f;0; ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)warn.rta / 1000, (float)crit.rta / 1000);
@@ -1619,20 +1619,20 @@ static void finish(int sig) {
       }
     }
     if (pl_mode) {
-      printf("%s%spl=%u%%;%u;%u;0;100 ",
+      printf("%s%spl=%u%%;%u;%u ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              host->pl, warn.pl, crit.pl);
     }
     if (rta_mode) {
       if (!host->rtmax || !host->rtmin) {
-        printf("%s%srtmax=U;;;; %s%srtmin=U;;;; ",
+        printf("%s%srtmax=Ums %s%srtmin=Ums ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "");
       } else {
-        printf("%s%srtmax=%0.3fms;;;; %s%srtmin=%0.3fms;;;; ",
+        printf("%s%srtmax=%0.3fms %s%srtmin=%0.3fms ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)host->rtmax / 1000,
@@ -1643,8 +1643,8 @@ static void finish(int sig) {
     }
     if (jitter_mode) {
       if (!host->jitter || !host->jitter_max || !host->jitter_min) {
-        printf("%s%sjitter_avg=U;%0.3f;%0.3f;0; %s%sjitter_max=U;;;; "
-             "%s%sjitter_min=U;;;; ",
+        printf("%s%sjitter_avg=Ums;%0.3f;%0.3f;0; %s%sjitter_max=Ums "
+             "%s%sjitter_min=U ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)warn.jitter, (float)crit.jitter,
@@ -1653,8 +1653,8 @@ static void finish(int sig) {
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "");
       } else {
-        printf("%s%sjitter_avg=%0.3fms;%0.3f;%0.3f;0; %s%sjitter_max=%0.3fms;;;; "
-             "%s%sjitter_min=%0.3fms;;;; ",
+        printf("%s%sjitter_avg=%0.3fms;%0.3f;%0.3f;0; %s%sjitter_max=%0.3fms "
+             "%s%sjitter_min=%0.3fms ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)host->jitter, (float)warn.jitter, (float)crit.jitter,

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1606,10 +1606,17 @@ static void finish(int sig) {
       puts("");
     }
     if (rta_mode) {
-      printf("%s%srta=%0.3fms;%0.3f;%0.3f;0; ",
+      if (!host->rta) {
+        printf("%s%srta=U;%0.3f;%0.3f;0; ",
+             (targets > 1 || perfdata_sep != NULL) ? host->name : "",
+             (perfdata_sep != NULL) ? perfdata_sep : "",
+             (float)warn.rta / 1000, (float)crit.rta / 1000);
+      } else {
+        printf("%s%srta=%0.3fms;%0.3f;%0.3f;0; ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)host->rta / 1000, (float)warn.rta / 1000, (float)crit.rta / 1000);
+      }
     }
     if (pl_mode) {
       printf("%s%spl=%u%%;%u;%u;0;100 ",
@@ -1618,16 +1625,35 @@ static void finish(int sig) {
              host->pl, warn.pl, crit.pl);
     }
     if (rta_mode) {
-      printf("%s%srtmax=%0.3fms;;;; %s%srtmin=%0.3fms;;;; ",
+      if (!host->rtmax || !host->rtmin) {
+        printf("%s%srtmax=U;;;; %s%srtmin=U;;;; ",
+             (targets > 1 || perfdata_sep != NULL) ? host->name : "",
+             (perfdata_sep != NULL) ? perfdata_sep : "",
+             (targets > 1 || perfdata_sep != NULL) ? host->name : "",
+             (perfdata_sep != NULL) ? perfdata_sep : "");
+      } else {
+        printf("%s%srtmax=%0.3fms;;;; %s%srtmin=%0.3fms;;;; ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)host->rtmax / 1000,
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)host->rtmin / 1000);
+      }
     }
     if (jitter_mode) {
-      printf("%s%sjitter_avg=%0.3fms;%0.3f;%0.3f;0; %s%sjitter_max=%0.3fms;;;; "
+      if (!host->jitter || !host->jitter_max || !host->jitter_min) {
+        printf("%s%sjitter_avg=U;%0.3f;%0.3f;0; %s%sjitter_max=U;;;; "
+             "%s%sjitter_min=U;;;; ",
+             (targets > 1 || perfdata_sep != NULL) ? host->name : "",
+             (perfdata_sep != NULL) ? perfdata_sep : "",
+             (float)warn.jitter, (float)crit.jitter,
+             (targets > 1 || perfdata_sep != NULL) ? host->name : "",
+             (perfdata_sep != NULL) ? perfdata_sep : "",
+             (targets > 1 || perfdata_sep != NULL) ? host->name : "",
+             (perfdata_sep != NULL) ? perfdata_sep : "");
+      } else {
+        printf("%s%sjitter_avg=%0.3fms;%0.3f;%0.3f;0; %s%sjitter_max=%0.3fms;;;; "
              "%s%sjitter_min=%0.3fms;;;; ",
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
@@ -1638,6 +1664,7 @@ static void finish(int sig) {
              (targets > 1 || perfdata_sep != NULL) ? host->name : "",
              (perfdata_sep != NULL) ? perfdata_sep : "",
              (float)host->jitter_min / 1000);
+      }
     }
     if (mos_mode) {
       printf("%s%smos=%0.1f;%0.1f;%0.1f;0;5 ",


### PR DESCRIPTION
When packet loss is 100%, then rta, rtmax, rtmin, jitter, jitter_max and jitter_min are set to 0ms in performance output. This of course is wrong: these values are unknown in this case. The Nagios plugin development guide at https://nagios-plugins.org/doc/guidelines.html#AEN200 allows to use "U" for unknown values.
I think we should output U instead of 0 in performance output when there is no reply from the target. U (Unknown) is a lot better than 0ms, which is pretty quick for a host that is down.