### PR TITLE
Fixes #648 Unable to check certificate with starttls in check_smtp

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -648,6 +648,7 @@ process_arguments (int argc, char **argv)
 #else
 			usage (_("SSL support not available - install OpenSSL and recompile"));
 #endif
+			break;
 		case 's':
 		/* ssl */
 			use_ssl = TRUE;


### PR DESCRIPTION
This pull request adds a break; to stop case 'D': Check SSL cert validity from falling through to case 's': ssl