### PR TITLE
check_ifstatus.pl: Don't query SNMP OID $snmpLocIfDescr unless $ifXTable is defined.

### DIFF
--- a/plugins-scripts/check_ifstatus.pl
+++ b/plugins-scripts/check_ifstatus.pl
@@ -136,11 +136,11 @@ if (!defined($session)) {
 }
 
 
-push(@snmpoids,$snmpLocIfDescr);
 push(@snmpoids,$snmpIfOperStatus);
 push(@snmpoids,$snmpIfAdminStatus);
 push(@snmpoids,$snmpIfDescr);
 push(@snmpoids,$snmpIfType);
+push(@snmpoids,$snmpLocIfDescr) if ( defined $ifXTable);
 push(@snmpoids,$snmpIfName) if ( defined $ifXTable);
 push(@snmpoids,$snmpIfAlias) if ( defined $ifXTable);
 


### PR DESCRIPTION
Fixes #650 causing error message "The requested table is empty or does not exist for 1.3.6.1.4.1.9.2.2.1.1.28 with snmp version 2" on SNMP agents that don't support that OID.