### PR TITLE
check_dig.c: make '-H' parameter optional, defaulting to local resolver stack

### DIFF
--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -94,8 +94,14 @@ main (int argc, char **argv)
   timeout_interval_dig = ceil((double) timeout_interval / (double) number_tries);
 
   /* get the command to run */
-  xasprintf (&command_line, "%s %s %s -p %d @%s %s %s +tries=%d +time=%d",
+  if (dns_server == NULL) {
+    xasprintf (&command_line, "%s %s %s %s %s +tries=%d +time=%d",
+ 	PATH_TO_DIG, dig_args, query_transport, query_address, record_type, number_tries, timeout_interval_dig);
+  }
+  else {
+    xasprintf (&command_line, "%s %s %s -p %d @%s %s %s +tries=%d +time=%d",
   	PATH_TO_DIG, dig_args, query_transport, server_port, dns_server, query_address, record_type, number_tries, timeout_interval_dig);
+  }
 
   alarm (timeout_interval);
   gettimeofday (&tv, NULL);
@@ -298,12 +304,6 @@ process_arguments (int argc, char **argv)
     if (c < argc) {
       host_or_die(argv[c]);
       dns_server = argv[c];
-    }
-    else {
-      if (strcmp(query_transport,"-6") == 0)
-        dns_server = strdup("::1");
-      else
-        dns_server = strdup ("127.0.0.1");
     }
   }
 


### PR DESCRIPTION
Normally, check_dig.c requires the explicit use of the -H command-line option to reference an IP number expected to be a functional resolver.  The dig utility does not require this however, since dig uses the local machine's resolver stack (e.g. /etc/resolv.conf) by default.  This commit makes check_dig's -H parameter optional.

Fixes #654