### PR TITLE
check_disk: Ignore fuse.portal as disk type

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -288,6 +288,7 @@ main (int argc, char **argv)
           (strcmp(me->me_type, "sysfs") == 0 || strcmp(me->me_type, "proc") == 0
         || strcmp(me->me_type, "debugfs") == 0 || strcmp(me->me_type, "tracefs") == 0
         || strcmp(me->me_type, "fusectl") == 0 || strcmp(me->me_type, "fuse.gvfsd-fuse") == 0
+        || strcmp(me->me_type, "fuse.portal") == 0
         || strcmp(me->me_type, "cgroup") == 0 || strstr(me->me_type, "tmpfs") != NULL))
       {
         if (last_me == NULL)


### PR DESCRIPTION
On Fedora 36 for logged in users (using Gnome) a mount is added:

```console
# mount | grep doc
portal on /run/user/1001/doc type fuse.portal (rw,nosuid,nodev,relatime,user_id=1001,group_id=1001)
```

This is something that can't be checked:

```console
# ls -l /run/user/1001/doc
ls: cannot access '/run/user/1001/doc': Permission denied
```

Since it can't be checked, ignoring it is the best solution.

I'll have to say that I don't have a setup to test this change and I'm very unfamiliar with the C coding practices. Feel free to consider this a bug report and properly implement this if that's easier.