### PR TITLE
Fix #663 - close MAILQ before analyzing the return code

### DIFF
--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -342,6 +342,8 @@ elsif ( $mailq eq "postfix" ) {
 
 
 	@lines = reverse <MAILQ>;
+	
+	close(MAILQ);
 
         if ( $? ) {
 		print "CRITICAL: Error code ".($?>>8)." returned from $utils::PATH_TO_MAILQ$mailq_args",$/;


### PR DESCRIPTION
`$?` is only set *after* `close()` has been called.

This fixes the issue where Postfix' `mailq` can't read the queue and returns garbage which can't be parsed by the later code.

Fixes #663