### PR TITLE
check_smtp: Permit certificate check with both --ssl and --starttls

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -311,16 +311,17 @@ main (int argc, char **argv)
 			printf("%s", buffer);
 		}
 
-#  ifdef USE_OPENSSL
-		  if ( check_cert ) {
+		}
+#endif
+
+#ifdef USE_OPENSSL
+		if ( (use_ssl || use_starttls) && check_cert ) {
                     result = np_net_ssl_check_cert(days_till_exp_warn, days_till_exp_crit);
 		    smtp_quit();
 		    my_close();
 		    return result;
 		  }
-#  endif /* USE_OPENSSL */
-		}
-#endif
+#endif /* USE_OPENSSL */
 
 		if (send_mail_from) {
 		  my_send(cmd_str, strlen(cmd_str));

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -648,6 +648,7 @@ process_arguments (int argc, char **argv)
 #else
 			usage (_("SSL support not available - install OpenSSL and recompile"));
 #endif
+			break;
 		case 's':
 		/* ssl */
 			use_ssl = TRUE;


### PR DESCRIPTION
This change moves the certificate check out of the block that initializes STARTTLS.  This should fix #651, but is based on work for #648 and #649.