### PR TITLE
check_disk: add ignore-missing option to return OK for missing fs

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -1259,9 +1259,17 @@ stat_path (struct parameter_list *p)
   if (stat (p->name, &stat_buf[0])) {
     if (verbose >= 3)
       printf("stat failed on %s\n", p->name);
-    if (!human_output)
+    if (ignore_missing == 1) {
+      if (!human_output) {
+        printf("DISK OK - ");
+      }
+      die (STATE_OK, _("%s %s: %s\n"), p->name, _("is not accessible (ignoring)"), strerror(errno));
+    } else {
+      if (!human_output) {
         printf("DISK %s - ", _("CRITICAL"));
-    die (STATE_CRITICAL, _("%s %s: %s\n"), p->name, _("is not accessible"), strerror(errno));
+      }
+      die (STATE_CRITICAL, _("%s %s: %s\n"), p->name, _("is not accessible"), strerror(errno));
+    }
   }
 }
 


### PR DESCRIPTION
There a situations when UNKNOWN services are not wanted when a filesystem is (temporarily) missing on a system. This new option helps to have the service in state OK.