### PR TITLE
Fix NEWS release date

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@ This file documents the major additions and syntax changes between releases.
 	check_mrtgtraf: fix incorrect out_pct performance data metric (#600)
 	check_ping: handle "bad checksum" warning from ping output (#616)
 
-2.4.3 2022-01-17
+2.4.3 2023-01-17
 	FIXES
 	check_dig: Improve matching logic when using -a (#652)
 	check_mailq: Fix garbled output when checking postfix (#663)


### PR DESCRIPTION
The release date of 2.4.3 is wrong... I fixed the correct year