### PR TITLE
configure needs full path to release file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,7 @@ AM_CONDITIONAL([RELEASE_PRESENT], [test -f $srcdir/release])
 
 # Also read in the version from it
 if test -f $srcdir/release; then
-	NP_RELEASE="$(<release)"
+	NP_RELEASE="$(<$srcdir/release)"
 else
 	NP_RELEASE="$PACKAGE_VERSION"
 fi


### PR DESCRIPTION
This solves the following error for VPATH builds:
```
/opt/src/nagios-plugins-2.4.4/configure: line 14326: release: No such file or directory
```