### PR TITLE
check_tcp: add --sni as alias for -N

### DIFF
--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -429,6 +429,7 @@ process_arguments (int argc, char **argv)
 		{"help", no_argument, 0, 'h'},
 		{"ssl", no_argument, 0, 'S'},
 		{"certificate", required_argument, 0, 'D'},
+		{"sni", required_argument, 0, 'N'},
 		{0, 0, 0, 0}
 	};
 


### PR DESCRIPTION
for the sake of readability and compatibility with monitoring-plugins/monitoring-plugins#1614 .

The latter matters for Icinga/icinga2#8208 .