### PR TITLE
check_by_ssh usually does not return out of bounds exitcode

### DIFF
--- a/plugins/t/check_by_ssh.t
+++ b/plugins/t/check_by_ssh.t
@@ -85,13 +85,13 @@ is($result->output, 'UNKNOWN - check_by_ssh: Remote command \'exit 3\' returned 
 $result = NPTest->testCmd(
 	"./check_by_ssh -i $ssh_key -H $ssh_service -C 'exit 7'"
 	);
-cmp_ok($result->return_code, '==', 7, "Exit with return code 7 (out of bounds)");
+cmp_ok($result->return_code, '==', 3, "Exit with return code 7 (out of bounds)");
 is($result->output, 'UNKNOWN - check_by_ssh: Remote command \'exit 7\' returned status 7', "Status text if command returned none (out of bounds)");
 
 $result = NPTest->testCmd(
 	"./check_by_ssh -i $ssh_key -H $ssh_service -C '$check[4]; exit 8'"
 	);
-cmp_ok($result->return_code, '==', 8, "Exit with return code 8 (out of bounds)");
+cmp_ok($result->return_code, '==', 3, "Exit with return code 8 (out of bounds)");
 is($result->output, $response[4], "Return proper status text even with unknown status codes");
 
 $result = NPTest->testCmd(


### PR DESCRIPTION
The `check_by_ssh` never exits with [exitcode > 3](https://github.com/nagios-plugins/nagios-plugins/blob/master/plugins/check_by_ssh.c#L122) when there is nothing on stderr, but `check_by_ssh.t` assumes it does.  Such assumption is wrong.