### PR TITLE
Fix number of tests for check_dns.t

### DIFF
--- a/plugins/t/check_dns.t
+++ b/plugins/t/check_dns.t
@@ -10,7 +10,7 @@ use NPTest;
 
 plan skip_all => "check_dns not compiled" unless (-x "check_dns");
 
-plan tests => 19;
+plan tests => 20;
 
 my $successOutput = '/DNS OK: [\.0-9]+ seconds? response time/';
 


### PR DESCRIPTION
One more test was added more than [8 years ago](https://github.com/nagios-plugins/nagios-plugins/commit/309e68f75c1c9f5519770ba78131793c52ef2edb) but number of expected tests was not changed.