### PR TITLE
check_dns: fix reverse mapping

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -263,7 +263,7 @@ main (int argc, char **argv)
         /* needed for non-query ptr\reverse lookup checks */
         else if (strstr(chld_out.line[i], ".in-addr.arpa") && !query_set) {
             if ((temp_buffer = strstr(chld_out.line[i], "name = "))) {
-                addresses[n_addresses++] = strdup(temp_buffer);
+                addresses[n_addresses++] = strdup(rindex(temp_buffer, ' ') + 1);
             }
             else {
                 xasprintf(&msg, "%s %s %s %s", _("Warning plugin error"));
@@ -358,7 +358,7 @@ main (int argc, char **argv)
     }
 
     /* compare query type to query found, if query type is ANY we can skip as any record is accepted*/
-    if (result == STATE_OK && strncmp(query_type, "", 1) && (strncmp(query_type, "-querytype=ANY", 15) != 0)) {
+    if (result == STATE_OK && query_set && (strncmp(query_type, "-querytype=ANY", 15) != 0)) {
         if (strncmp(query_type, query_found, 16) != 0) {
           if (verbose) {
               printf( "%s %s %s %s %s\n", _("Failed query for"), query_type, _("only found"), query_found, _(", or nothing"));
@@ -634,7 +634,6 @@ validate_arguments ()
         /*query_type = "-querytype=A";*/
         strcpy(query_type, "-querytype=");
         strcat(query_type, "A");
-        query_set = TRUE;
     }
 
     return OK;


### PR DESCRIPTION
Before the fix:
```
$ plugins/check_dns -H 8.8.8.8
DNS CRITICAL - query type of -querytype=A was not found for 8.8.8.8
$ plugins/check_dns -H 8.8.8.8 -q PTR
DNS OK: 0.029 seconds response time. 8.8.8.8 returns dns.google.|time=0.028740s;;;0.000000
$
```
After the fix:
```
$ plugins/check_dns -H 8.8.8.8
DNS OK: 0.034 seconds response time. 8.8.8.8 returns dns.google.|time=0.034408s;;;0.000000
$ plugins/check_dns -H 8.8.8.8 -q PTR
DNS OK: 0.032 seconds response time. 8.8.8.8 returns dns.google.|time=0.031715s;;;0.000000
$
```

Fixes #598.

This also removes the extra `name = ` from the output when run without `-q PTR` (see #598).  This is what [plugins/t/check_dns.t](https://github.com/nagios-plugins/nagios-plugins/blob/master/plugins/t/check_dns.t#L96) expects.