### PR TITLE
check_fping.t: unresolvable address returns unknown status

### DIFF
--- a/plugins/t/check_fping.t
+++ b/plugins/t/check_fping.t
@@ -31,7 +31,7 @@ if ( -x "./check_fping" )
 {
   $t += checkCmd( "./check_fping $host_responsive",    0,       $successOutput );
   $t += checkCmd( "./check_fping $host_nonresponsive", [ 1, 2 ] );
-  $t += checkCmd( "./check_fping $hostname_invalid",   [ 1, 2 ] );
+  $t += checkCmd( "./check_fping $hostname_invalid",   3 );
 }
 else
 {


### PR DESCRIPTION
When `check_fping` tries unresolvable address it returns 3, not either 1 or 2 as expected by the `check_fping.t` test:
```
$ plugins/check_fping 8.8.8.8 ; echo $?
FPING OK - 8.8.8.8 (loss=0%, rta=4.700000 ms)|loss=0%;;;0;100 rta=0.004700s;;;0.000000
0
$ plugins/check_fping 10.0.0.1 ; echo $?
FPING CRITICAL - 10.0.0.1 (loss=100% )|loss=100%;;;0;100
2
$ plugins/check_fping do-no-exist ; echo $?
FPING UNKNOWN - IP address not found
3
$
```