### PR TITLE
check_load.t: consider new per CPU format

### DIFF
--- a/plugins/t/check_load.t
+++ b/plugins/t/check_load.t
@@ -13,6 +13,7 @@ my $res;
 my $loadValue = "[0-9]+\.?[0-9]+";
 my $successOutput = "/^OK - load average: $loadValue, $loadValue, $loadValue/";
 my $failureOutput = "/^CRITICAL - load average: $loadValue, $loadValue, $loadValue/";
+my $failureOutputPerCPU = "/^CRITICAL - load average per CPU: $loadValue, $loadValue, $loadValue/";
 
 plan tests => 11;
 
@@ -26,7 +27,7 @@ like( $res->output, $failureOutput, "Output OK");
 
 $res = NPTest->testCmd( "./check_load -r -w 0,0,0 -c 0,0,0" );
 cmp_ok( $res->return_code, 'eq', 2, "Load over 0 with per cpu division");
-like( $res->output, $failureOutput, "Output OK");
+like( $res->output, $failureOutputPerCPU, "Output OK");
 
 $res = NPTest->testCmd( "./check_load -w 100 -c 100,110" );
 cmp_ok( $res->return_code, 'eq', 0, "Plugin can handle non-triplet-arguments");


### PR DESCRIPTION
The `check_load` plugin output was [changed](https://github.com/nagios-plugins/nagios-plugins/commit/1e8db3deaa83dc7beca78d6382c435de37e835e3) several years ago, but related test was not updated.