### PR TITLE
check_ssh.t: update timeout message

### DIFF
--- a/plugins/t/check_ssh.t
+++ b/plugins/t/check_ssh.t
@@ -37,7 +37,7 @@ $result = NPTest->testCmd(
     "./check_ssh -H $host_nonresponsive -t 2"
     );
 cmp_ok($result->return_code, '==', 2, "Exit with return code 0 (OK)");
-like($result->output, '/^CRITICAL - Socket timeout after 2 seconds/', "Status text if command returned none (OK)");
+like($result->output, '/^CRITICAL - Socket timeout/', "Status text if command returned none (OK)");
 
 
 


### PR DESCRIPTION
The timeout message no longer contains `after X seconds` since Oct 2015 (see `netutils.c`).