### PR TITLE
Fix error with check log filling up tmp directory

### DIFF
--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -206,7 +206,6 @@ fi
 if [ ! -d "$TMPDIR" ];then
 	TMPDIR="/tmp"
 fi
-echo "$TMPDIR"
 
 # Copy the logfile to a temporary file, to prevent diff from
 # never finishing when $logfile continues to be written to
@@ -258,6 +257,8 @@ lastentry=$(egrep "$query" "$tempdiff" | tail -1)
 
 rm -f "$tempdiff"
 cat "$logfile" > "$oldlog"
+# Need to remove the temp file otherwise it just fills up the temp directory
+rm -f "$templog"
 
 if [ "$count" = "0" ]; then # no matches, exit with no error
     echo "Log check ok - 0 pattern matches found|match=$count;;;0"


### PR DESCRIPTION
The check_log script will create a folder in the `/tmp` directory called something like `temp_check_log.BhlvxjsLE9` that if done enough times on sufficiently large log files would fill the entire disk space. This ensures that this script removes the temporary files it creates.

Also I get rid of an echo that isn't necessary. 