### PR TITLE
Fixes #720 - check_snmp numeric OID name bug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 This file documents the major additions and syntax changes between releases.
 
+2.4.7 2023-10-30
+	FIXES
+	check_snmp: Fixed issue where OID name with numeric data was misinterpreted as OID value (#720)
+
 2.4.6 2023-08-01
 	FIXES
 	check_log: Fixed issue where /tmp directory would fill with unnecessary information (#724)

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -496,8 +496,10 @@ main (int argc, char **argv)
 		/* Process this block for numeric comparisons */
 		/* Make some special values,like Timeticks numeric only if a threshold is defined */
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {
-			ptr = strpbrk (show, "-0123456789");
-
+			/* Find the first instance of the '(' character - the value of the OID should be contained in parens */
+			ptr = strpbrk(show, "(");
+			ptr++;
+			
 			if (ptr == NULL)
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
 			while (i >= response_size) {

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -498,10 +498,10 @@ main (int argc, char **argv)
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {
 			/* Find the first instance of the '(' character - the value of the OID should be contained in parens */
 			ptr = strpbrk(show, "(");
-			ptr++;
-			
 			if (ptr == NULL)
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
+			ptr++;
+			
 			while (i >= response_size) {
 				response_size += OID_COUNT_STEP;
 				response_value = realloc(response_value, response_size * sizeof(*response_value));

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -500,7 +500,7 @@ main (int argc, char **argv)
 			ptr = strpbrk(show, "(");
 			if (ptr == NULL)
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
-			ptr++;
+			ptr++; /* Move to the first character after the '(' */
 			
 			while (i >= response_size) {
 				response_size += OID_COUNT_STEP;

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -490,6 +490,7 @@ main (int argc, char **argv)
 			is_ticks = 1;
 		}
 		else {
+			/* This branch is expected to be error-handling only */
 			show = response;
 			show_length = strlen(show);
 			for (int i = 0; i < show_length; i++){


### PR DESCRIPTION
Testing Plan:
- Tested plugin using this command: `/usr/local/nagios/libexec/check_snmp -H 192.168.223.19 -C public -P 2c -o ipv6IpForwarding.0  -v -v -v -v -w 2 -c 6`
- Before making the changes, this command returns:
```
/usr/bin/snmpget -Le -t 3 -r 5 -m ALL -v 2c [context] [authpriv] 192.168.223.19:161 ipv6IpForwarding.0
IP-MIB::ipv6IpForwarding.0 = INTEGER: notForward1000ing(2)
Processing oid 1 (line 1)
oidname: IP-MIB::ipv6IpForwarding.0
response: INTEGER: notForward1000ing(2)

SNMP CRITICAL - 1000 | IP-MIB::ipv6IpForwarding.0=1000;2;6
```
- Notice that the response uses the value 1000 which is in the OID name rather than the actual OID value (which is 2).
- After making the changes, this command returns:
```
/usr/bin/snmpget -Le -t 3 -r 5 -m ALL -v 2c [context] [authpriv] 192.168.223.19:161 ipv6IpForwarding.0
IP-MIB::ipv6IpForwarding.0 = INTEGER: notForward1000ing(2)
Processing oid 1 (line 1)
oidname: IP-MIB::ipv6IpForwarding.0
response: INTEGER: notForward1000ing(2)

SNMP OK - 2 | IP-MIB::ipv6IpForwarding.0=2;2;6
```
- And it correctly gets and uses the value 2.