### PR TITLE
Fix #679 by adding whitespace check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 This file documents the major additions and syntax changes between releases.
 
+2.4.7 2023-10-30
+	FIXES
+	check_snmp: Fixed issue where plugin returned OK for missin OID (#679)
+
 2.4.6 2023-08-01
 	FIXES
 	check_log: Fixed issue where /tmp directory would fill with unnecessary information (#724)

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -94,6 +94,7 @@ void print_usage (void);
 void print_help (void);
 
 #include "regex.h"
+#include <ctype.h>
 char regex_expect[MAX_INPUT_BUFFER] = "";
 regex_t preg;
 regmatch_t pmatch[10];
@@ -490,6 +491,11 @@ main (int argc, char **argv)
 		}
 		else
 			show = response;
+			for (int i = 0; i < strlen(show); i++){
+				if (isspace(show[i])){
+					die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
+				}
+			}
 
 		iresult = STATE_DEPENDENT;
 

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -489,14 +489,14 @@ main (int argc, char **argv)
 			show = strpbrk (show, "-0123456789");
 			is_ticks = 1;
 		}
-		else
+		else {
 			show = response;
 			for (int i = 0; i < strlen(show); i++){
 				if (isspace(show[i])){
 					die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
 				}
 			}
-
+		}
 		iresult = STATE_DEPENDENT;
 
 		/* Process this block for numeric comparisons */

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -204,7 +204,7 @@ main (int argc, char **argv)
 	char *previous_string=NULL;
 	char *ap=NULL;
 	char *state_string=NULL;
-	size_t response_length, current_length, string_length;
+	size_t response_length, current_length, string_length, show_length;
 	char *temp_string=NULL;
 	char *quote_string=NULL;
 	time_t current_time;
@@ -491,7 +491,8 @@ main (int argc, char **argv)
 		}
 		else {
 			show = response;
-			for (int i = 0; i < strlen(show); i++){
+			show_length = strlen(show);
+			for (int i = 0; i < show_length; i++){
 				if (isspace(show[i])){
 					die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
 				}


### PR DESCRIPTION
The only difference between the correct UNKNOWN output when threshold parameters are given vs not, is - when given threshold params - the response passes the if statement:

`if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {`

which is immediately after that else. It then promptly fails what used to be a check for any of (-0123456789) - replaced by my check for parens - and dies. That's why the error is caught when thresholds are given and not when they aren't. My impression is that if it's chill to die in this if statement then it's chill to die directly before given the same circumstances (namely when the response is an error message). I just put a whitespace check in the else and a subsequent die() if it fails.