### PR TITLE
fix: removed a line made redundant (and breaking) by other bug fix

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -486,7 +486,6 @@ main (int argc, char **argv)
 		}
 		else if (strstr (response, "Timeticks: ")) {
 			show = strstr (response, "Timeticks: ");
-			show = strpbrk (show, "-0123456789");
 			is_ticks = 1;
 		}
 		else {


### PR DESCRIPTION
### Description: 
The modified line was made redundant and breaking by changes made in #720 (as far as I can tell it was redundant before but non-breaking). Before this change it would strbrk to the first digit and then strbrk for an open paren which would return null. Now it just strbrk's for an open paren just like other snmpget return values. 

### Testing Plan
- Run `./check_snmp -H hostname -C community_string -o sysUpTime.0 -m RFC1213-MIB` (with a valid hostname and community_string) before the change. It will return something like: `No valid data returned (20455651) 2 days, 8:49:16.51)` 
- Run `./check_snmp -H hostname -C community_string -o sysUpTime.0 -m RFC1213-MIB` (with a valid hostname and community_string) after the change. It should return something like: `SNMP OK - Timeticks: (96520) 0:16:05.20 | RFC1213-MIB::sysUpTime.0=96520` 