### PR TITLE
check_icmp: Uncheck return values of set*id() family functions

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -725,7 +725,9 @@ int main(int argc, char **argv) {
   }
 
   /* now drop privileges (no effect if not setsuid or geteuid() == 0) */
-  setuid(getuid());
+  if (setuid(getuid()) == -1) {
+    crash("dropping privileges failed");
+  }
 
 #ifdef SO_TIMESTAMP
   if (setsockopt(icmp_sock, SOL_SOCKET, SO_TIMESTAMP, &on, sizeof(on))) {


### PR DESCRIPTION
A setuid() return value is not checked in nagio's check_icmp plugin:

https://github.com/nagios-plugins/nagios-plugins/blob/ee69a7d8aeaef375bbe5680deebbf59ce4455a68/plugins-root/check_icmp.c#L726C1-L729C1

man 2 setuid() states the following:

> RETURN VALUE
>       On success, zero is returned.  On error, -1 is returned, and errno is set to indicate the error.
>
>       Note: there are cases where setuid() can fail even when the caller is UID 0; it is a grave security error to omit checking for a failure return from setuid().

In the unlikely event where setuid() fails, privileges of the plugin would not be dropped and commands would be run as root. This would lead to privilege escalation.

The attached patch fixes this by aborting execution when such an event occurs.