### PR TITLE
check_disk: make -X a regex list

### DIFF
--- a/lib/utils_disk.c
+++ b/lib/utils_disk.c
@@ -39,6 +39,17 @@ np_add_name (struct name_list **list, const char *name)
   *list = new_entry;
 }
 
+/* Initialises a new regex at the begin of list via regcomp(3) */
+int
+np_add_regex (struct regex_list **list, const char *regex, int cflags)
+{
+  struct regex_list *new_entry = (struct regex_list *) malloc (sizeof *new_entry);
+  new_entry->next = *list;
+  *list = new_entry;
+
+  return regcomp(&new_entry->regex, regex, cflags);
+}
+
 /* Initialises a new parameter at the end of list */
 struct parameter_list *
 np_add_parameter(struct parameter_list **list, const char *name)

--- a/lib/utils_disk.c
+++ b/lib/utils_disk.c
@@ -28,6 +28,7 @@
 
 #include "common.h"
 #include "utils_disk.h"
+#include <string.h>
 
 void
 np_add_name (struct name_list **list, const char *name)
@@ -181,6 +182,30 @@ np_find_name (struct name_list *list, const char *name)
     }
   }
   return FALSE;
+}
+
+/* Returns TRUE if name is in list */
+bool
+np_find_regmatch (struct regex_list *list, const char *name)
+{
+  int len;
+  regmatch_t m;
+
+  if (name == NULL) {
+    return false;
+  }
+
+  len = strlen(name);
+
+  for (; list; list = list->next) {
+    /* Emulate a full match as if surrounded with ^( )$
+       by checking whether the match spans the whole name */
+    if (!regexec(&list->regex, name, 1, &m, 0) && m.rm_so == 0 && m.rm_eo == len) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 int

--- a/lib/utils_disk.h
+++ b/lib/utils_disk.h
@@ -39,6 +39,7 @@ struct parameter_list
 void np_add_name (struct name_list **list, const char *name);
 int np_find_name (struct name_list *list, const char *name);
 int np_seen_name (struct name_list *list, const char *name);
+int np_add_regex (struct regex_list **list, const char *regex, int cflags);
 struct parameter_list *np_add_parameter(struct parameter_list **list, const char *name);
 struct parameter_list *np_find_parameter(struct parameter_list *list, const char *name);
 struct parameter_list *np_del_parameter(struct parameter_list *item, struct parameter_list *prev);

--- a/lib/utils_disk.h
+++ b/lib/utils_disk.h
@@ -40,6 +40,7 @@ void np_add_name (struct name_list **list, const char *name);
 int np_find_name (struct name_list *list, const char *name);
 int np_seen_name (struct name_list *list, const char *name);
 int np_add_regex (struct regex_list **list, const char *regex, int cflags);
+bool np_find_regmatch (struct regex_list *list, const char *name);
 struct parameter_list *np_add_parameter(struct parameter_list **list, const char *name);
 struct parameter_list *np_find_parameter(struct parameter_list *list, const char *name);
 struct parameter_list *np_del_parameter(struct parameter_list *item, struct parameter_list *prev);

--- a/lib/utils_disk.h
+++ b/lib/utils_disk.h
@@ -10,6 +10,12 @@ struct name_list
   struct name_list *next;
 };
 
+struct regex_list
+{
+  regex_t regex;
+  struct regex_list *next;
+};
+
 struct parameter_list
 {
   char *name;


### PR DESCRIPTION
fixes #733

## Tests

```
➜  nagios-plugins git:(733) plugins/check_disk -w 1 -c 2 -X apfs
DISK CRITICAL - free space: /dev 0 MiB (0,00% inode=0%);| /dev=0MiB;-1;-2;0;0
➜  nagios-plugins git:(733) plugins/check_disk -w 1 -c 2 -X apf
DISK CRITICAL - free space: / 161588 MiB (33,89% inode=100%); /dev 0 MiB (0,00% inode=0%); /System/Volumes/Preboot 161588 MiB (33,89% inode=100%); /System/Volumes/VM 161588 MiB (33,89% inode=100%); /System/Volumes/Update 161588 MiB (33,89% inode=100%); /System/Volumes/Data 161588 MiB (33,89% inode=100%);| /=315213MiB;476801;476800;0;476802 /dev=0MiB;-1;-2;0;0 /System/Volumes/Preboot=315213MiB;476801;476800;0;476802 /System/Volumes/VM=315213MiB;476801;476800;0;476802 /System/Volumes/Update=315213MiB;476801;476800;0;476802 /System/Volumes/Data=315213MiB;476801;476800;0;476802
➜  nagios-plugins git:(733) plugins/check_disk -w 1 -c 2 -X 'ap.*'
DISK CRITICAL - free space: /dev 0 MiB (0,00% inode=0%);| /dev=0MiB;-1;-2;0;0
➜  nagios-plugins git:(733)
```