### PR TITLE
Potential robust fix for check_snmp issues

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 This file documents the major additions and syntax changes between releases.
 
+2.4.9
+	FIXES
+	check_snmp: Robustly fixes incorrect integer return value parsing (#749)
+
 2.4.8 2023-12-7
 	FIXES
 	check_snmp: Fixed issue where Timeticks would incorrectly show "No valid data returned" (#743)

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -504,14 +504,12 @@ main (int argc, char **argv)
 		/* Make some special values,like Timeticks numeric only if a threshold is defined */
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {
 			/* Find the first instance of the '(' character - the value of the OID should be contained in parens */
-			if (ptr = strpbrk(show, "(")) {
+			if ((ptr = strpbrk(show, "(")) != NULL) { /* Timetick */
 				ptr++; /* Move to the first character after the '(' */
-			} else {
-				ptr = strpbrk(show, "-0123456789");
-			}
-			if (ptr == NULL)
+			} else if ((ptr = strpbrk(show, "-0123456789")) == NULL) { /* Counter, gauge, or integer */
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
-			
+			}
+
 			while (i >= response_size) {
 				response_size += OID_COUNT_STEP;
 				response_value = realloc(response_value, response_size * sizeof(*response_value));

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -494,7 +494,7 @@ main (int argc, char **argv)
 			show_length = strlen(show);
 			for (j = 0; j < show_length; j++){
 				if (isspace(show[j])){
-					die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
+					die (STATE_UNKNOWN,_("No valid data returned at 497 (%s)\n"), show);
 				}
 			}
 		}

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -505,7 +505,7 @@ main (int argc, char **argv)
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {
 			/* Find the first instance of the '(' character - the value of the OID should be contained in parens */
 			if ((ptr = strpbrk(show, "(")) != NULL) { /* Timetick */
-				ptr++; /* Move to the first character after the '(' */
+				ptr++;
 			} else if ((ptr = strpbrk(show, "-0123456789")) == NULL) { /* Counter, gauge, or integer */
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
 			}

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -504,10 +504,13 @@ main (int argc, char **argv)
 		/* Make some special values,like Timeticks numeric only if a threshold is defined */
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {
 			/* Find the first instance of the '(' character - the value of the OID should be contained in parens */
-			ptr = strpbrk(show, "(");
+			if (ptr = strpbrk(show, "(")) {
+				ptr++; /* Move to the first character after the '(' */
+			} else {
+				ptr = strpbrk(show, "-0123456789");
+			}
 			if (ptr == NULL)
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
-			ptr++; /* Move to the first character after the '(' */
 			
 			while (i >= response_size) {
 				response_size += OID_COUNT_STEP;

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -494,7 +494,7 @@ main (int argc, char **argv)
 			show_length = strlen(show);
 			for (j = 0; j < show_length; j++){
 				if (isspace(show[j])){
-					die (STATE_UNKNOWN,_("No valid data returned at 497 (%s)\n"), show);
+					die (STATE_UNKNOWN,_("Unrecognized OID name returned (%s)\n"), show);
 				}
 			}
 		}


### PR DESCRIPTION
### DESCRIPTION
- This fix maintains the fix to issue #720 while hopefully addressing the subsequent problems noted in issue #743. 
- With this change, the integer return value from snmpget is only accessed via searching for open parentheses if said character exists, otherwise it parses as before - by checking for the first instance of "-0123456789". 
- NOTE: There are still potentially edge cases (namely a return value with an oidname that both has no parentheses and has integers in the name - but I truly hope that isn't possible). 
### TESTING
- I do not have the equipment required to test specific MIBs but this change largely reverts my previous change so particularly extensive testing is not necessary for such MIBs that no longer worked with the change made in 2.4.7.
- For those who encountered issues with 2.4.7 and 2.4.8, please test this branch with the OIDs that were broken with those versions and, ideally, other OIDs you test in your environments.
- Please note if OIDs that were working previously (in 2.4.6) now return a message akin to "UNKNOWN: No Valid data returned" and mark the expected return value. Especially if it begins with something other than: INTEGER, STRING, COUNTER64, COUNTER32, OID, Timeticks, GAUGE, or GAUGE32.