### PR TITLE
Handle snmp IpAddress responses

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -488,6 +488,9 @@ main (int argc, char **argv)
 			show = strstr (response, "Timeticks: ");
 			is_ticks = 1;
 		}
+		else if (strstr (response, "IpAddress: ")) {
+			show = strstr (response, "IpAddress: ") + 11;
+		}
 		else {
 			/* This branch is expected to be error-handling only */
 			show = response;


### PR DESCRIPTION
The recent changes (post 2.4.6) to `check_snmp` mean that attempting to do string matching on OIDs that return an IP address value will fail as they will traverse the "error path" despite there not actually being an error.

This fixes that though it does also change the behaviour by removing the `IpAddress: ` prefix from the string being matched which is in line with how other responses are handled.