### PR TITLE
Fix incorrect check_proc test

### DIFF
--- a/plugins/tests/check_procs.t
+++ b/plugins/tests/check_procs.t
@@ -68,9 +68,9 @@ SKIP: {
     like( $result->output, '/^PROCS OK: 0 processes with UID = -2 \(nobody\), args \'UsB\'/', "Output correct" );
 }
 
-$result = NPTest->testCmd( "$command --ereg-argument-array='mdworker.*501'" );
+$result = NPTest->testCmd( "$command --ereg-argument-array='com\.apple.*501'" );
 is( $result->return_code, 0, "Checking regexp search of arguments" );
-is( $result->output, "PROCS OK: 1 process with regex args 'mdworker.*501' | procs=1;;;0;", "Output correct" );
+is( $result->output, "PROCS OK: 1 process with regex args 'com\.apple.*501' | procs=1;;;0;", "Output correct" );
 
 $result = NPTest->testCmd( "$command --vsz 1000000" );
 is( $result->return_code, 0, "Checking filter by VSZ" );


### PR DESCRIPTION
Per the --help output of check_procs
```
--ereg-argument-array=STRING
   Only scan for processes with args that contain the regex STRING.
```
This argument specifically runs the regex against the _arguments_ of a process, but the test assumed this meant it was running the regex against the entire string.