### PR TITLE
Add spaces to regex of check_file_age.t

### DIFF
--- a/plugins-scripts/t/check_file_age.t
+++ b/plugins-scripts/t/check_file_age.t
@@ -12,7 +12,7 @@ my $successOutput = '/^FILE_AGE OK: /';
 my $warningOutput = '/^FILE_AGE WARNING: /';
 my $criticalOutput = '/^FILE_AGE CRITICAL: /';
 my $unknownOutput = '/^FILE_AGE UNKNOWN: /';
-my $performanceOutput = '/ \| age=[0-9]+s;[0-9]+;[0-9]+ size=[0-9]+B;[0-9]+;[0-9]+;0$/';
+my $performanceOutput = '/ \| age=[0-9]+s;[0-9]+;[0-9]+ size=[0-9]+B;[0-9]+;[0-9]+;0  $/';
 
 my $result;
 my $temp_file = "/tmp/check_file_age.tmp";


### PR DESCRIPTION
Pretty simple, plugin has two spaces at the end of output. Need to make sure regex matches this