### PR TITLE
check_dig Exact Match

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 This file documents the major additions and syntax changes between releases.
 
+2.4.10 2024-XX-XX
+	FIXES
+	check_dig: Fixed issue where exact matching broke backwards compatability, and added new option to enforce exact matching (#777)
+
 2.4.9 2024-03-21
 	FIXES
 	check_snmp: Robustly fixes incorrect integer return value parsing (#749)

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -57,6 +57,7 @@ char *dns_server = NULL;
 char *dig_args = "";
 char *query_transport = "";
 int verbose = FALSE;
+int exact = FALSE;
 int server_port = DEFAULT_PORT;
 int number_tries = DEFAULT_TRIES;
 double warning_interval = UNDEFINED;
@@ -150,7 +151,7 @@ main (int argc, char **argv)
         }
 
         t = tt; /* consider the right-side token, does it match ex? */
-        if ( (strcasestr( t, ex ) == t) && (strlen( t ) == strlen( ex )) ) {
+        if ( (!exact && strcasestr( t, ex)) || ((strcasestr( t, ex ) == t) && (strlen( t ) == strlen( ex ))) ) {
           result = STATE_OK;
           msg = chld_out.line[i];
           break;
@@ -225,6 +226,7 @@ process_arguments (int argc, char **argv)
     {"verbose", no_argument, 0, 'v'},
     {"version", no_argument, 0, 'V'},
     {"help", no_argument, 0, 'h'},
+    {"exact", no_argument, 0, 'e'},
     {"record_type", required_argument, 0, 'T'},
     {"expected_address", required_argument, 0, 'a'},
     {"port", required_argument, 0, 'p'},
@@ -237,7 +239,7 @@ process_arguments (int argc, char **argv)
     return ERROR;
 
   while (1) {
-    c = getopt_long (argc, argv, "hVvt:l:H:w:c:T:p:a:A:46r:", longopts, &option);
+    c = getopt_long (argc, argv, "hVvt:l:H:w:c:T:p:a:A:46r:e", longopts, &option);
 
     if (c == -1 || c == EOF)
       break;
@@ -296,6 +298,9 @@ process_arguments (int argc, char **argv)
       break;
     case 'v':                 /* verbose */
       verbose = TRUE;
+      break;
+    case 'e':
+      exact = TRUE;
       break;
     case 'T':
       record_type = optarg;

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -151,7 +151,7 @@ main (int argc, char **argv)
         }
 
         t = tt; /* consider the right-side token, does it match ex? */
-        if ( (!exact && strcasestr( t, ex)) || ((strcasestr( t, ex ) == t) && (strlen( t ) == strlen( ex ))) ) {
+        if ( (!exact && strcasestr( t, ex )) || ((strcasestr( t, ex ) == t) && (strlen( t ) == strlen( ex ))) ) {
           result = STATE_OK;
           msg = chld_out.line[i];
           break;

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -151,7 +151,7 @@ main (int argc, char **argv)
         }
 
         t = tt; /* consider the right-side token, does it match ex? */
-        if ( (!exact && strcasestr( t, ex )) || ((strcasestr( t, ex ) == t) && (strlen( t ) == strlen( ex ))) ) {
+        if ( (!exact && strcasestr( t, ex )) || (strcmp( t, ex ) == 0) ) {
           result = STATE_OK;
           msg = chld_out.line[i];
           break;

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -388,6 +388,8 @@ print_help (void)
   printf ("    %s\n",_("Pass STRING as argument(s) to dig"));
   printf (" %s\n","-r, --retries=INTEGER");
   printf ("    %s\n",_("Number of retries passed to dig, timeout is divided by this value (Default: 3)"));
+  printf (" %s\n","-e, --exact");
+  printf ("    %s\n",_("Match records exactly. If not set, fuzzy matches."));
   printf (UT_WARN_CRIT);
   printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
   printf (UT_VERBOSE);


### PR DESCRIPTION
### SUMMARY
- There was an [issue](https://github.com/nagios-plugins/nagios-plugins/commit/cbdfd8a9bd83ed22dc6e9b3e5104ed81de388596) reported with the check_dig plugin where it returned OK on records that only partially matched the expected address. 
- The fix was to exact match records.
- This fix was not backwards-compatible and broke (at least) calls to check_dig that matched TXT records. This specific issue occurs  because DNS TXT records are quote-wrapped and the expected address is not. 

### FIX
- To maintain backwards-compatibility, my changes alter the exact match change, making it only occur when an additional argument is provided. If this argument is not provided, the method used prior to the last commit is used (partial match).

### TESTING PLAN (command ----> EXPECTED OUTPUT)
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --expected_address=3.184.215.2 ----> WARNING
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --expected_address=3.184.215.1 ----> OK
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --expected_address=3.184.215.1 -e ----> WARNING
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --record_type=TXT --expected_address=6r4wtj10lt2hw0zhyhk7cgzzffhjp7f ----> OK
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --record_type=TXT --expected_address=6r4wtj10lt2hw0zhyhk7cgzzffhjp7f -e ----> WARNING
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --record_type=TXT --expected_address=6r4wtj10lt2hw0zhyhk7cgzzffhjp7fl ----> OK
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --record_type=TXT --expected_address=6r4wtj10lt2hw0zhyhk7cgzzffhjp7fl -e ----> WARNING
- ./check_dig  --hostname=8.8.8.8 --query_address=example.org --record_type=TXT --expected_address='"6r4wtj10lt2hw0zhyhk7cgzzffhjp7fl"' -e ----> OK

Try quote-wrapping, double quote-wrapping, wrapping in escaped quotes the expected address. The results should be the same as not wrapped at all.

Try more calls. Make sure they work as they should.

I am not exactly certain what the purpose of the "left match" branch is. It was added in the same commit as the exact match change but it seems unrelated. If anyone has a good idea, please let me know. I am not certain if I should add fuzzy matching to this branch. Currently I have not as it wasn't present before the breaking commit and therefore doesn't impact backwards-compatibility.