### PR TITLE
check_http.t should use SNI when connecting to https://www.mozilla.com/

### DIFF
--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -159,7 +159,7 @@ SKIP: {
         cmp_ok( $res->return_code, "==", 0, "Can read https for www.e-paycobalt.com (uses AES certificate)" );
 
 
-        $res = NPTest->testCmd( "./check_http -H www.mozilla.com -u /firefox -f follow" );
+        $res = NPTest->testCmd( "./check_http -H www.mozilla.com --sni -u /firefox -f follow" );
         is( $res->return_code, 0, "Redirection based on location is okay");
 
         $res = NPTest->testCmd( "./check_http -H www.mozilla.com --extended-perfdata" );


### PR DESCRIPTION
We need to adapt the `check_http.t` test to recent changes made at the https://www.mozilla.com/ web server.

Fixes #779