### PR TITLE
Update check_dhcp.c for GCC14 in Solaris and HP-UX

### DIFF
--- a/plugins-root/check_dhcp.c
+++ b/plugins-root/check_dhcp.c
@@ -82,7 +82,7 @@ const char *email = "devel@nagios-plugins.org";
 #include <signal.h>
 #include <sys/dlpi.h>
 #include <sys/poll.h>
-#include <sys/stropts.h>
+#include <stropts.h>
 
 #define bcopy(source, destination, length) memcpy(destination, source, length)
 


### PR DESCRIPTION
<sys/stropts.h> is specified, but the correct value is <stropts.h>.

check_dhcp.o make error at GCC14 #799 
https://github.com/nagios-plugins/nagios-plugins/issues/799