### PR TITLE
Require snmpgetnext to build check_snmp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1491,7 +1491,7 @@ then
 	AC_DEFINE_UNQUOTED(PATH_TO_SNMPGET,"$PATH_TO_SNMPGET",[path to snmpget binary])
 	EXTRAS="$EXTRAS check_hpjd check_snmp\$(EXEEXT)"
 else
-	AC_MSG_WARN([Get snmpget from http://net-snmp.sourceforge.net to make check_hpjd and check_snmp plugins])
+	AC_MSG_WARN([Get snmpget from https://net-snmp.sourceforge.io/ to make check_hpjd and check_snmp plugins])
 fi
 
 AC_PATH_PROG(PATH_TO_SNMPGETNEXT,snmpgetnext)

--- a/configure.ac
+++ b/configure.ac
@@ -1486,23 +1486,21 @@ AC_ARG_WITH(snmpget_command,
             ACX_HELP_STRING([--with-snmpget-command=PATH],
                             [Path to snmpget command]),
             PATH_TO_SNMPGET=$withval)
-if test -n "$PATH_TO_SNMPGET"
-then
+AS_IF([test -n "$PATH_TO_SNMPGET"], [
 	AC_DEFINE_UNQUOTED(PATH_TO_SNMPGET,"$PATH_TO_SNMPGET",[path to snmpget binary])
 	EXTRAS="$EXTRAS check_hpjd check_snmp\$(EXEEXT)"
-else
+], [
 	AC_MSG_WARN([Get snmpget from https://net-snmp.sourceforge.io/ to make check_hpjd and check_snmp plugins])
-fi
+])
 
 AC_PATH_PROG(PATH_TO_SNMPGETNEXT,snmpgetnext)
 AC_ARG_WITH(snmpgetnext_command,
             ACX_HELP_STRING([--with-snmpgetnext-command=PATH],
                             [Path to snmpgetnext command]),
             PATH_TO_SNMPGETNEXT=$withval)
-if test -n "$PATH_TO_SNMPGETNEXT"
-then
+AS_IF([test -n "$PATH_TO_SNMPGETNEXT"], [
 	AC_DEFINE_UNQUOTED(PATH_TO_SNMPGETNEXT,"$PATH_TO_SNMPGETNEXT",[path to snmpgetnext binary])
-fi
+])
 
 if ( $PERL -M"Net::SNMP 3.6" -e 'exit' 2>/dev/null  )
 then

--- a/configure.ac
+++ b/configure.ac
@@ -1486,20 +1486,29 @@ AC_ARG_WITH(snmpget_command,
             ACX_HELP_STRING([--with-snmpget-command=PATH],
                             [Path to snmpget command]),
             PATH_TO_SNMPGET=$withval)
-AS_IF([test -n "$PATH_TO_SNMPGET"], [
-	AC_DEFINE_UNQUOTED(PATH_TO_SNMPGET,"$PATH_TO_SNMPGET",[path to snmpget binary])
-	EXTRAS="$EXTRAS check_hpjd check_snmp\$(EXEEXT)"
-], [
-	AC_MSG_WARN([Get snmpget from https://net-snmp.sourceforge.io/ to make check_hpjd and check_snmp plugins])
-])
 
 AC_PATH_PROG(PATH_TO_SNMPGETNEXT,snmpgetnext)
 AC_ARG_WITH(snmpgetnext_command,
             ACX_HELP_STRING([--with-snmpgetnext-command=PATH],
                             [Path to snmpgetnext command]),
             PATH_TO_SNMPGETNEXT=$withval)
-AS_IF([test -n "$PATH_TO_SNMPGETNEXT"], [
-	AC_DEFINE_UNQUOTED(PATH_TO_SNMPGETNEXT,"$PATH_TO_SNMPGETNEXT",[path to snmpgetnext binary])
+
+AS_IF([test -n "$PATH_TO_SNMPGET"], [
+	AC_DEFINE_UNQUOTED(PATH_TO_SNMPGET,"$PATH_TO_SNMPGET",[path to snmpget binary])
+	EXTRAS="$EXTRAS check_hpjd"
+
+	dnl PATH_TO_SNMPGETNEXT is used unconditionally in check_snmp:
+	dnl
+	dnl   https://github.com/nagios-plugins/nagios-plugins/issues/788
+	dnl
+	AS_IF([test -n "$PATH_TO_SNMPGETNEXT"], [
+		AC_DEFINE_UNQUOTED(PATH_TO_SNMPGETNEXT,"$PATH_TO_SNMPGETNEXT",[path to snmpgetnext binary])
+		EXTRAS="$EXTRAS check_snmp\$(EXEEXT)"
+	], [
+		AC_MSG_WARN([Get snmpgetnext from https://net-snmp.sourceforge.io/ to build the check_snmp plugin])
+	])
+], [
+	AC_MSG_WARN([Get snmpget from https://net-snmp.sourceforge.io/ to build the check_hpjd and check_snmp plugins])
 ])
 
 if ( $PERL -M"Net::SNMP 3.6" -e 'exit' 2>/dev/null  )


### PR DESCRIPTION
Currently, `configure.ac` performs checks for two programs,

1. snmpget
2. snmpgetnext

The second one is used by `check_snmp` only when a particular flag is passed, but in reality, `snmpgetnext` is still required because unless its `PATH_TO_SNMPGETNEXT` is defined, compilaction of `check_snmp.c` will fail.

I have no idea how you might wind up with `snmpget` and not `snmpgetnext`, but at least one person has managed to do it and file a Gentoo bug about it.  To fix the issue, this PR will disable the building of `check_snmp` if `snmpgetnext` is missing. It also emits a warning in that case.

Closes:
* https://github.com/nagios-plugins/nagios-plugins/issues/788
