### PR TITLE
check_http: Passing NULL to die() can cause segmentation fault

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1082,7 +1082,7 @@ check_http (void)
         result = np_net_ssl_init_with_hostname_version_and_cert(sd, (use_sni ? host_name : NULL), ssl_version, client_cert, client_privkey);
         if (verbose) printf ("SSL initialized\n");
         if (result != STATE_OK)
-            die (STATE_CRITICAL, NULL);
+            die (STATE_CRITICAL, "");
         microsec_ssl = deltime (tv_temp);
         elapsed_time_ssl = (double)microsec_ssl / 1.0e6;
         if (check_cert == TRUE) {


### PR DESCRIPTION
The `die()` function in `utils_base.c` does not allow the `fmt` pointer to be `NULL`. This causes a segmentation fault on FreeBSD.

This PR replaces `NULL` with an empty string (`""`).

This fixes #563