### PR TITLE
check_icmp: Handle `::` IPv6 address correctly (fixes #825)

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1715,7 +1715,7 @@ static int add_target_ip(char *arg, struct sockaddr_storage *in) {
   if (((address_family == AF_INET && (sin->sin_addr.s_addr == INADDR_NONE ||
                                       sin->sin_addr.s_addr == INADDR_ANY))) ||
       (address_family == AF_INET6 &&
-       sin6->sin6_addr.s6_addr == in6addr_any.s6_addr)) {
+       IN6_IS_ADDR_UNSPECIFIED(&sin6->sin6_addr))) {
     return -1;
   }
 

--- a/plugins-root/t/check_icmp.t
+++ b/plugins-root/t/check_icmp.t
@@ -66,6 +66,18 @@ is( $res->return_code, 3, "No hostname" );
 like( $res->output, '/No hosts to check/', "Output with appropriate error message");
 
 $res = NPTest->testCmd(
+	"$sudo ./check_icmp 0.0.0.0"
+	);
+is( $res->return_code, 3, "Invalid IPv4 address" );
+like( $res->output, '/No hosts to check/', "Output with appropriate error message");
+
+$res = NPTest->testCmd(
+	"$sudo ./check_icmp -6 ::"
+	);
+is( $res->return_code, 3, "Invalid IPv6 address" );
+like( $res->output, '/No hosts to check/', "Output with appropriate error message");
+
+$res = NPTest->testCmd(
 	"$sudo ./check_icmp -H $host_nonresponsive -w 10000ms,100% -c 10000ms,100% -n 1 -m 0"
 	);
 is( $res->return_code, 0, "One host nonresponsive - zero required" );


### PR DESCRIPTION
Unlike `0.0.0.0` the address `::` didn't result
in exit code 3 with the output "No hosts to check". Now, this is the case.

Closes #825 