### PR TITLE
#803 | Fix Compilation on AIX

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1274,9 +1274,7 @@ static int recvfrom_wto(int sock, void *buf, unsigned int len,
   char ans_data[4096];
   struct msghdr hdr;
   struct iovec iov;
-#ifdef SO_TIMESTAMP
   struct cmsghdr *chdr;
-#endif
 
   if (!*timo) {
     if (debug)

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1274,7 +1274,7 @@ static int recvfrom_wto(int sock, void *buf, unsigned int len,
   char ans_data[4096];
   struct msghdr hdr;
   struct iovec iov;
-  struct cmsghdr *chdr;
+  struct cmsghdr *chdr = NULL;
 
   if (!*timo) {
     if (debug)


### PR DESCRIPTION
Without SO_TIMESTAMP, *chdr is not declared but is still being used. This errors when compiling on OSs that lack SO_TIMESTAMP, such as AIX. This PR declares and initializes *chdr regardless of the presence of SO_TIMESTAMP. 

Fixes #803 