### PR TITLE
Fix gettimeofday call in check_icmp.c

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1331,9 +1331,13 @@ static int recvfrom_wto(int sock, void *buf, unsigned int len,
   }
 #endif /* SO_TIMESTAMP */
 
+#ifdef SO_TIMESTAMP
   if (!chdr) {
     gettimeofday(tv, &tz);
   }
+#else
+  gettimeofday(tv, &tz);
+#endif
   return (ret);
 }
 


### PR DESCRIPTION
This fix used to compile check_icmp.c on IBM AIX.

The compilation error was 
check_icmp.c:1334:8: error: 'chdr' undeclared (first use in this function); did you mean 'hdr'?
 1334 |   if (!chdr) {
      |        ^~~~
      |        hdr
check_icmp.c:1334:8: note: each undeclared identifier is reported only once for each function it appears in